### PR TITLE
Update display of Premium Employers block

### DIFF
--- a/packages/global/components/blocks/premium-employers.marko
+++ b/packages/global/components/blocks/premium-employers.marko
@@ -19,27 +19,29 @@ $ const { title } = input;
 $ const blockName = "premium-employers";
 
 <marko-web-query|{ nodes: allNodes }| name="website-scheduled-content" params=queryParams>
-  $ const nodes = shuffle(allNodes).slice(0, displayLimit);
-  <if(title)>
-    <marko-web-element block-name=blockName name="header">
-      ${title}
-    </marko-web-element>
-  </if>
-  <default-theme-card-deck-flow cols=displayLimit nodes=nodes modifiers=[blockName]>
-    <@slot|{ node }|>
-      <global-content-node
-        image-position="top"
-        card=true
-        flush=true
-        full-height=true
-        with-teaser=false
-        with-dates=false
-        with-section=false
-        modifiers=[blockName]
-        node=node
-      >
-        <@image ar="1:1" fluid=true />
-      </global-content-node>
-    </@slot>
-  </default-theme-card-deck-flow>
+  <marko-web-block name=blockName>
+    $ const nodes = shuffle(allNodes).slice(0, displayLimit);
+    <if(title)>
+      <marko-web-element block-name=blockName name="header">
+        ${title}
+      </marko-web-element>
+    </if>
+    <default-theme-card-deck-flow cols=displayLimit nodes=nodes modifiers=[blockName]>
+      <@slot|{ node }|>
+        <global-content-node
+          image-position="top"
+          card=true
+          flush=true
+          full-height=true
+          with-teaser=false
+          with-dates=false
+          with-section=false
+          modifiers=[blockName]
+          node=node
+        >
+          <@image ar="16:9" fluid=true />
+        </global-content-node>
+      </@slot>
+    </default-theme-card-deck-flow>
+  </marko-web-block>
 </marko-web-query>

--- a/packages/global/scss/components/blocks/_premium-employers.scss
+++ b/packages/global/scss/components/blocks/_premium-employers.scss
@@ -9,3 +9,23 @@
     @include skin-typography($style: "section-header");
   }
 }
+
+.node {
+  $self: &;
+  &--premium-employers {
+    #{ $self }__body {
+      display: none;
+    }
+  }
+}
+
+.page-wrapper {
+  &__section {
+    &--break-container {
+      .premium-employers {
+        padding-top: 50px;
+        padding-bottom: 50px;
+      }
+    }
+  }
+}

--- a/sites/ccnewsnow.com/server/templates/content/index.marko
+++ b/sites/ccnewsnow.com/server/templates/content/index.marko
@@ -23,15 +23,6 @@ $ const { id, type, pageNode, ...rest } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/ccnewsnow.com/server/templates/content/index.marko
+++ b/sites/ccnewsnow.com/server/templates/content/index.marko
@@ -23,16 +23,16 @@ $ const { id, type, pageNode, ...rest } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="content_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/ccnewsnow.com/server/templates/index.marko
+++ b/sites/ccnewsnow.com/server/templates/index.marko
@@ -85,16 +85,16 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="home_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/ccnewsnow.com/server/templates/index.marko
+++ b/sites/ccnewsnow.com/server/templates/index.marko
@@ -85,15 +85,6 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="home_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/ccnewsnow.com/server/templates/website-section/index.marko
+++ b/sites/ccnewsnow.com/server/templates/website-section/index.marko
@@ -25,15 +25,6 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/ccnewsnow.com/server/templates/website-section/index.marko
+++ b/sites/ccnewsnow.com/server/templates/website-section/index.marko
@@ -25,16 +25,16 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="section_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/diverseeducation.com/server/templates/content/index.marko
+++ b/sites/diverseeducation.com/server/templates/content/index.marko
@@ -23,15 +23,6 @@ $ const { id, type, pageNode, ...rest } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/diverseeducation.com/server/templates/content/index.marko
+++ b/sites/diverseeducation.com/server/templates/content/index.marko
@@ -23,16 +23,16 @@ $ const { id, type, pageNode, ...rest } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="content_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/diverseeducation.com/server/templates/index.marko
+++ b/sites/diverseeducation.com/server/templates/index.marko
@@ -69,16 +69,16 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="home_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/diverseeducation.com/server/templates/index.marko
+++ b/sites/diverseeducation.com/server/templates/index.marko
@@ -69,15 +69,6 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="home_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/diverseeducation.com/server/templates/website-section/index.marko
+++ b/sites/diverseeducation.com/server/templates/website-section/index.marko
@@ -25,15 +25,6 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/diverseeducation.com/server/templates/website-section/index.marko
+++ b/sites/diverseeducation.com/server/templates/website-section/index.marko
@@ -25,16 +25,16 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="section_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/diversemilitary.net/server/templates/content/index.marko
+++ b/sites/diversemilitary.net/server/templates/content/index.marko
@@ -23,15 +23,6 @@ $ const { id, type, pageNode, ...rest } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/diversemilitary.net/server/templates/content/index.marko
+++ b/sites/diversemilitary.net/server/templates/content/index.marko
@@ -23,16 +23,16 @@ $ const { id, type, pageNode, ...rest } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="content_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/diversemilitary.net/server/templates/index.marko
+++ b/sites/diversemilitary.net/server/templates/index.marko
@@ -85,16 +85,16 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="home_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/diversemilitary.net/server/templates/index.marko
+++ b/sites/diversemilitary.net/server/templates/index.marko
@@ -85,15 +85,6 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="home_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/diversemilitary.net/server/templates/website-section/index.marko
+++ b/sites/diversemilitary.net/server/templates/website-section/index.marko
@@ -25,15 +25,6 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/diversemilitary.net/server/templates/website-section/index.marko
+++ b/sites/diversemilitary.net/server/templates/website-section/index.marko
@@ -25,16 +25,16 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="section_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/divhealth.net/server/templates/content/index.marko
+++ b/sites/divhealth.net/server/templates/content/index.marko
@@ -23,15 +23,6 @@ $ const { id, type, pageNode, ...rest } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/divhealth.net/server/templates/content/index.marko
+++ b/sites/divhealth.net/server/templates/content/index.marko
@@ -23,16 +23,16 @@ $ const { id, type, pageNode, ...rest } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="content_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/divhealth.net/server/templates/index.marko
+++ b/sites/divhealth.net/server/templates/index.marko
@@ -85,16 +85,16 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="home_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 

--- a/sites/divhealth.net/server/templates/index.marko
+++ b/sites/divhealth.net/server/templates/index.marko
@@ -85,15 +85,6 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="home_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/divhealth.net/server/templates/website-section/index.marko
+++ b/sites/divhealth.net/server/templates/website-section/index.marko
@@ -25,15 +25,6 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <!-- <@section|{ aliases }|>
-    <global-gam-define-display-ad
-      name="rotation"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section> -->
-
   <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>

--- a/sites/divhealth.net/server/templates/website-section/index.marko
+++ b/sites/divhealth.net/server/templates/website-section/index.marko
@@ -25,16 +25,16 @@ $ const { id, alias, name, pageNode } = input;
     </div>
   </@section>
 
-  <@section|{ aliases }|>
+  <!-- <@section|{ aliases }|>
     <global-gam-define-display-ad
       name="rotation"
       position="section_page"
       aliases=aliases
       modifiers=["inter-block"]
     />
-  </@section>
+  </@section> -->
 
-  <@section>
+  <@section modifiers=["break-container"]>
     <global-premium-employers-block title="Premium Employers" />
   </@section>
 


### PR DESCRIPTION
Replace ad above this block and made the premium employer block break out of the page container with the gray background.

<img width="1180" alt="Screen Shot 2021-08-10 at 10 14 53 AM" src="https://user-images.githubusercontent.com/3845869/128893117-6085d333-c09d-4ce6-ab35-3a6860d07aec.png">
