### PR TITLE
Add Magazine landing pages(magazine|publication|issue) & homepage block.  

### DIFF
--- a/packages/global/components/blocks/magazine-issue-cards.marko
+++ b/packages/global/components/blocks/magazine-issue-cards.marko
@@ -1,0 +1,33 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import queryFragment from "../../graphql/fragments/section-feed-block";
+
+$ const queryParams = {
+  ...input.queryParams,
+  sectionAlias: input.alias,
+  queryFragment,
+};
+
+$ const blockName = "section-feed";
+$ const countOnly = defaultValue(input.countOnly, false);
+
+<if(countOnly)>
+  <global-query-total-count|data| name="website-scheduled-content" params=queryParams>
+    <${input.renderBody} ...data />
+  </global-query-total-count>
+</if>
+<else>
+  <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+    <marko-web-node-list
+      inner-justified=true
+      flush-x=true
+      flush-y=false
+      modifiers=[blockName]
+    >
+      <@nodes nodes=nodes>
+        <@slot|{ node }|>
+          <global-section-feed-content-node node=node />
+        </@slot>
+      </@nodes>
+    </marko-web-node-list>
+  </marko-web-query>
+</else>

--- a/packages/global/components/blocks/magazine-publications.marko
+++ b/packages/global/components/blocks/magazine-publications.marko
@@ -1,0 +1,13 @@
+import publicationListFragment from "../../graphql/fragments/magazine-publication-list";
+
+<marko-web-query|{ nodes }| name="magazine-publications" params={ queryFragmet: publicationListFragment }>
+  <for|publication| of=nodes>
+    <marko-web-query|{ node: latestIssue }| name="magazine-latest-issue" params={ publicationId: publication.id }>
+      <default-theme-magazine-publication-card-block publication-id=publication.id issue-id=latestIssue.id>
+        <@header>
+          <marko-web-magazine-publication-name tag=null obj=publication link=true />
+        </@header>
+      </default-theme-magazine-publication-card-block>
+    </marko-web-query>
+  </for>
+</marko-web-query>

--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -148,5 +148,8 @@
   },
   "<global-top-stories-menu-block>": {
     "template": "./top-stories-menu.marko"
+  },
+  "<global-magazine-publications-block>": {
+    "template": "./magazine-publications.marko"
   }
 }

--- a/packages/global/components/flows/magazine-issue-archive.marko
+++ b/packages/global/components/flows/magazine-issue-archive.marko
@@ -1,0 +1,12 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const { aliases } = input;
+$ const nodes = getAsArray(input, "nodes");
+
+<if(nodes.length)>
+  <default-theme-card-deck-flow nodes=nodes modifiers=input.modifiers cols=4>
+    <@slot|{ node }|>
+      <global-magazine-issue-archive-node node=node flush=input.flush with-title=input.withTitle />
+    </@slot>
+  </default-theme-card-deck-flow>
+</if>

--- a/packages/global/components/flows/magazine-latest-issue.marko
+++ b/packages/global/components/flows/magazine-latest-issue.marko
@@ -1,0 +1,16 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+
+$ const nodes = [];
+$ const issueNode = getAsObject(input, "issueNode");
+$ if (issueNode) nodes.push(issueNode);
+
+<marko-web-node-list inner-justified=true>
+  <if(input.header)>
+    <@header ...input.header />
+  </if>
+  <@nodes nodes=nodes>
+    <@slot|{ node: issue }| position="at" index=0>
+      <global-magazine-latest-issue-node node=issue />
+    </@slot>
+  </@nodes>
+</marko-web-node-list>

--- a/packages/global/components/flows/magazine-latest-issue.marko
+++ b/packages/global/components/flows/magazine-latest-issue.marko
@@ -4,7 +4,14 @@ $ const nodes = [];
 $ const issueNode = getAsObject(input, "issueNode");
 $ if (issueNode) nodes.push(issueNode);
 
-<marko-web-node-list inner-justified=true>
+<marko-web-node-list
+  inner-justified=true
+  flush-x=true
+  flush-y=true
+  modifiers=[
+    "latest-issue",
+  ]
+>
   <if(input.header)>
     <@header ...input.header />
   </if>

--- a/packages/global/components/flows/marko.json
+++ b/packages/global/components/flows/marko.json
@@ -1,5 +1,23 @@
 {
   "taglib-imports": [
     "./content/marko.json"
-  ]
+  ],
+  "<global-magazine-issue-archive-flow>": {
+    "template": "./magazine-issue-archive.marko",
+    "@nodes": "array",
+    "@flush": {
+      "type": "boolean",
+      "default-value": false
+    },
+    "@with-title": {
+      "type": "boolean",
+      "default-value": true
+    },
+    "@modifiers": "array"
+  },
+  "<global-magazine-latest-issue-flow>": {
+    "template": "./magazine-latest-issue.marko",
+    "<header>": {},
+    "@issue-node": "object"
+  }
 }

--- a/packages/global/components/nodes/magazine-issue-archive.marko
+++ b/packages/global/components/nodes/magazine-issue-archive.marko
@@ -1,0 +1,28 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+
+$ const issue = getAsObject(input, "node");
+$ const publication = getAsObject(issue, "publication");
+$ const coverImage = getAsObject(issue, "coverImage");
+$ const alt = `${publication.name} ${issue.name}`;
+
+<marko-web-node
+  image-position="top"
+  card=defaultValue(input.card, true)
+  flush=defaultValue(input.flush, false)
+  full-height=defaultValue(input.fullHeight, false)
+>
+  <@image
+    src=coverImage.src
+    alt=(coverImage.alt || alt)
+    fluid=true
+    ar="3:4"
+    width=defaultValue(input.imageWidth, 400)
+    link={ href: issue.canonicalPath, title: alt }
+  />
+  <@body>
+    <@title tag="h5" show=defaultValue(input.withTitle, true)>
+      <marko-web-magazine-issue-name tag=null obj=issue link={ title: alt } />
+    </@title>
+  </@body>
+</marko-web-node>

--- a/packages/global/components/nodes/magazine-latest-issue.marko
+++ b/packages/global/components/nodes/magazine-latest-issue.marko
@@ -1,0 +1,32 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+
+$ const issue = getAsObject(input, "node");
+$ const publication = getAsObject(issue, "publication");
+$ const coverImage = getAsObject(issue, "coverImage");
+$ const linkTitle = `${publication.name} ${issue.name}`;
+
+<marko-web-node
+  image-position="top"
+  card=defaultValue(input.card, false)
+  flush=defaultValue(input.flush, true)
+>
+  <@image
+    src=coverImage.src
+    alt=(coverImage.alt || linkTitle)
+    fluid=true
+    ar="3:4"
+    width=(input.imageWidth || 300)
+    link={ href: issue.canonicalPath, title: linkTitle }
+  />
+  <@body>
+    <@title tag="h5">
+      <marko-web-magazine-issue-name tag=null obj=issue link={ title: linkTitle } />
+    </@title>
+    <@footer>
+      <@left>
+        <default-theme-magazine-publication-buttons publication=publication issue=issue />
+      </@left>
+    </@footer>
+  </@body>
+</marko-web-node>

--- a/packages/global/components/nodes/marko.json
+++ b/packages/global/components/nodes/marko.json
@@ -57,6 +57,25 @@
     "@attrs": "object",
     "@link-attrs": "object"
   },
+  "<global-magazine-latest-issue-node>": {
+    "template": "./magazine-latest-issue.marko",
+    "@node": "object",
+    "@flush": "boolean",
+    "@card": "boolean",
+    "@image-width": {
+      "type": "number",
+      "default-value": 300
+    }
+  },
+  "<global-magazine-issue-archive-node>": {
+    "template": "./magazine-issue-archive.marko",
+    "@node": "object",
+    "@image-width": "number",
+    "@full-height": "boolean",
+    "@flush": "boolean",
+    "@card": "boolean",
+    "@with-title": "boolean"
+  },
   "<global-author-node>": {
     "template": "./author.marko"
   },

--- a/packages/global/components/query-total-count.marko
+++ b/packages/global/components/query-total-count.marko
@@ -37,6 +37,16 @@ $ const optionsMap = {
       }
     `,
     variables: { input: params },
+  },
+  "magazine-active-issues": {
+    query: gql`
+      query MagazineActiveIssuesCount($input: MagazineActiveIssuesQueryInput!) {
+        result: magazineActiveIssues(input: $input) {
+          totalCount
+        }
+      }
+    `,
+    variables: { input: params },
   }
 };
 $ const options = optionsMap[input.name];

--- a/packages/global/graphql/fragments/magazine-issue-archive.js
+++ b/packages/global/graphql/fragments/magazine-issue-archive.js
@@ -1,0 +1,19 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazineIssueArchiveFragment on MagazineIssue {
+  id
+  name
+  canonicalPath
+  coverImage {
+    id
+    src(input: { options: { auto: "format,compress", q: 70 } })
+  }
+  publication {
+    id
+    name
+  }
+}
+
+`;

--- a/packages/global/graphql/fragments/magazine-issue-page.js
+++ b/packages/global/graphql/fragments/magazine-issue-page.js
@@ -1,0 +1,23 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazineIssuePageFragment on MagazineIssue {
+  id
+  name
+  description
+  digitalEditionUrl
+  canonicalPath
+  coverImage {
+    id
+    src(input: { options: { auto: "format,compress", q: 70 } })
+  }
+  publication {
+    id
+    name
+    subscribeUrl
+    canonicalPath
+  }
+}
+
+`;

--- a/packages/global/graphql/fragments/magazine-latest-issue.js
+++ b/packages/global/graphql/fragments/magazine-latest-issue.js
@@ -1,0 +1,22 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazineCurrentIssueFragment on MagazineIssue {
+  id
+  name
+  digitalEditionUrl
+  canonicalPath
+  coverImage {
+    id
+    src(input: { options: { auto: "format,compress", q: 70 } })
+  }
+  publication {
+    id
+    name
+    subscribeUrl
+    canonicalPath
+  }
+}
+
+`;

--- a/packages/global/graphql/fragments/magazine-publication-list.js
+++ b/packages/global/graphql/fragments/magazine-publication-list.js
@@ -1,0 +1,11 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazinePublicationListFragment on MagazinePublication {
+  id
+  name
+  canonicalPath
+}
+
+`;

--- a/packages/global/graphql/fragments/magazine-publication-page.js
+++ b/packages/global/graphql/fragments/magazine-publication-page.js
@@ -1,0 +1,12 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazinePublicationPageFragment on MagazinePublication {
+  id
+  name
+  description
+  canonicalPath
+}
+
+`;

--- a/packages/global/routes/index.js
+++ b/packages/global/routes/index.js
@@ -2,6 +2,7 @@ const htmlSitemap = require('@parameter1/base-cms-marko-web-html-sitemap/routes'
 const dynamicPage = require('./dynamic-page');
 const feed = require('./feed');
 // const identityX = require('./identity-x');
+const magazine = require('./magazine');
 const nativeX = require('./native-x');
 const printContent = require('./print-content');
 const publicFiles = require('./public-files');
@@ -16,6 +17,9 @@ module.exports = (app, siteConfig) => {
 
   // Feed
   feed(app);
+
+  // magazine
+  magazine(app);
 
   // // IdentityX (user routing and app context)
   // identityX(app);

--- a/packages/global/routes/magazine.js
+++ b/packages/global/routes/magazine.js
@@ -1,0 +1,22 @@
+const { withMagazineIssue, withMagazinePublication } = require('@parameter1/base-cms-marko-web/middleware');
+const index = require('../templates/magazine');
+const publication = require('../templates/magazine/publication');
+const publicationFragment = require('../graphql/fragments/magazine-publication-page');
+const issue = require('../templates/magazine/issue');
+const issueFragment = require('../graphql/fragments/magazine-issue-page');
+
+module.exports = (app) => {
+  app.get('/magazine', (req, res) => {
+    res.marko(index);
+  });
+
+  app.get('/magazine/:id([a-fA-F0-9]{24})', withMagazinePublication({
+    template: publication,
+    queryFragment: publicationFragment,
+  }));
+
+  app.get('/magazine/:id(\\d+)', withMagazineIssue({
+    template: issue,
+    queryFragment: issueFragment,
+  }));
+};

--- a/packages/global/scss/components/_magazine.scss
+++ b/packages/global/scss/components/_magazine.scss
@@ -1,0 +1,9 @@
+.magazine-publication-buttons {
+  $self: &;
+  display: flex;
+  #{ $self }__button {
+    padding: 6px 12px;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+}

--- a/packages/global/scss/components/_magazine.scss
+++ b/packages/global/scss/components/_magazine.scss
@@ -9,13 +9,28 @@
 }
 
 .magazine-publication-card-block {
+  &__header {
+    padding-right: 0;
+    padding-left: 0;
+  }
   &__body {
+    padding-right: 0;
+    padding-left: 0;
     .issue-archive-cover {
       margin-bottom: $block-spacer;
     }
   }
 }
-
+.page {
+  &--magazine-issue {
+    .magazine-publication-card-block {
+      &__body {
+        padding-right: 10px;
+        padding-left: 10px;
+      }
+    }
+  }
+}
 .node-list {
   $self: &;
   &--latest-issue {

--- a/packages/global/scss/components/_magazine.scss
+++ b/packages/global/scss/components/_magazine.scss
@@ -8,6 +8,14 @@
   }
 }
 
+.magazine-publication-card-block {
+  &__body {
+    .issue-archive-cover {
+      margin-bottom: $block-spacer;
+    }
+  }
+}
+
 .node-list {
   $self: &;
   &--latest-issue {

--- a/packages/global/scss/components/_magazine.scss
+++ b/packages/global/scss/components/_magazine.scss
@@ -7,3 +7,29 @@
     white-space: nowrap;
   }
 }
+
+.node-list {
+  $self: &;
+  &--latest-issue {
+    #{ $self }__nodes {
+      padding-top: 10px;
+    }
+    #{ $self }__footer {
+      display: flex;
+      justify-content: space-between;
+      @include marko-web-node-list-border(border-top);
+      padding-bottom: map-get($spacers, "block");
+      font-weight: $font-weight-bold;
+    }
+    .node-list {
+      &__node:first-child {
+        @include marko-web-node-list-border(border-top);
+        padding-top: map-get($spacers, "block-sm");
+      }
+      &__nodes {
+        flex-grow: 0;
+        border-bottom: none;
+      }
+    }
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -16,6 +16,7 @@
 @import "./components/author-published-node";
 @import "./components/comments";
 @import "./components/content-page";
+@import "./components/magazine";
 @import "./components/page-wrapper";
 @import "./components/pagination-controls";
 @import "./components/site-footer";

--- a/packages/global/templates/magazine/index.marko
+++ b/packages/global/templates/magazine/index.marko
@@ -1,0 +1,34 @@
+$ const { site, GAM } = out.global;
+
+$ const type = "magazines";
+$ const title = "Magazines";
+$ const description = site.get("magazines.description");
+
+<marko-web-default-page-layout type=type title=title description=description>
+  <@head>
+    <marko-web-gtm-default-context|{ context }| type=type>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-default-context>
+  </@head>
+  <@page>
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-page-wrapper class="mb-block">
+      <@section>
+        <div class="row">
+          <div class="col">
+            <default-theme-breadcrumbs-with-home>
+              <@item>${title}</@item>
+            </default-theme-breadcrumbs-with-home>
+            <h1 class="page-wrapper__title">${title}</h1>
+            <if(description)>
+              <p class="page-wrapper__deck">${description}</p>
+            </if>
+          </div>
+        </div>
+      </@section>
+      <@section>
+        <global-magazine-publications-block />
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-default-page-layout>

--- a/packages/global/templates/magazine/index.marko
+++ b/packages/global/templates/magazine/index.marko
@@ -1,4 +1,4 @@
-$ const { site, GAM } = out.global;
+$ const { site } = out.global;
 
 $ const type = "magazines";
 $ const title = "Magazines";
@@ -11,8 +11,16 @@ $ const description = site.get("magazines.description");
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
+      <@section|{ aliases }|>
+        <global-gam-define-display-ad
+          name="rotation"
+          position="magazine_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
+
       <@section>
         <div class="row">
           <div class="col">

--- a/packages/global/templates/magazine/issue.marko
+++ b/packages/global/templates/magazine/issue.marko
@@ -1,0 +1,100 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import issueFragment from "../../graphql/fragments/magazine-issue-archive";
+
+$ const { GAM, site } = out.global;
+$ const { id, pageNode } = data;
+
+<marko-web-magazine-issue-page-layout id=id>
+  <@head>
+    <marko-web-gtm-magazine-issue-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-magazine-issue-context>
+  </@head>
+  <@page>
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
+    <marko-web-page-wrapper class="mb-block">
+      <@section>
+        <div class="row">
+          <div class="col">
+            <marko-web-resolve-page|{ data: issue }| node=pageNode>
+              <default-theme-breadcrumbs-with-home>
+                <@item><marko-web-link href="/magazine">Magazines</marko-web-link></@item>
+                <@item><marko-web-magazine-publication-name tag=null obj=issue.publication link=true /></@item>
+                <@item><marko-web-magazine-issue-name tag=null obj=issue /></@item>
+              </default-theme-breadcrumbs-with-home>
+              <h1 class="page-wrapper__title">
+                <marko-web-link href='/magazine'>
+                  BizBash Magazine
+                </marko-web-link>
+              </h1>
+              <div class="magazine-publication-card-block">
+                <div class="magazine-publication-card-block__body">
+                  <div class="row">
+                    <div class="col-lg-8 pl-0">
+                      <marko-web-node image-position="left" modifiers=["flush"] flush=false>
+                        <@image
+                          src=issue.coverImage.src
+                          alt=(issue.coverImage.alt || issue.name)
+                          fluid=false
+                          ar="3:4"
+                          width=300
+                          link={ href: issue.canonicalPath, title: issue.name }
+                        />
+                        <@body>
+                          <@title tag="h5">
+                            <marko-web-magazine-issue-name tag=null obj=issue />
+                          </@title>
+                          <@text modifiers=["teaser"]>
+                            <marko-web-magazine-issue-description tag=null obj=issue />
+                          </@text>
+                          <@footer>
+                            <@left>
+                              <default-theme-magazine-publication-buttons publication=issue.publication issue=issue />
+                            </@left>
+                          </@footer>
+                        </@body>
+                      </marko-web-node>
+                    </div>
+                    <marko-web-query|{ nodes: issues }| name="magazine-active-issues"
+                      params={
+                        publicationId: issue.publication.id,
+                        excludeIssueIds: [issue.id],
+                        queryFragment: issueFragment,
+                        limit: 9,
+                        requiresCoverImage: true
+                      }
+                    >
+                      <div class="col-lg-4">
+                        <div class="row">
+                          <for|issue| of=issues>
+                            <div class="col-4 issue-archive-cover">
+                              <marko-web-node
+                                image-position="top"
+                                card=true
+                                flush=true
+                                full-height=true
+                              >
+                                <@image
+                                  src=issue.coverImage.src
+                                  alt=(issue.coverImage.alt || issue.name)
+                                  fluid=true
+                                  ar="3:4"
+                                  width=190
+                                  link={ href: issue.canonicalPath, title: issue.name }
+                                />
+                              </marko-web-node>
+                            </div>
+                          </for>
+                        </div>
+                      </div>
+                    </marko-web-query>
+                  </div>
+                </div>
+              </div>
+            </marko-web-resolve-page>
+          </div>
+        </div>
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-magazine-issue-page-layout>

--- a/packages/global/templates/magazine/issue.marko
+++ b/packages/global/templates/magazine/issue.marko
@@ -1,7 +1,7 @@
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import issueFragment from "../../graphql/fragments/magazine-issue-archive";
 
-$ const { GAM, site } = out.global;
+$ const { site } = out.global;
 $ const { id, pageNode } = data;
 
 <marko-web-magazine-issue-page-layout id=id>
@@ -11,8 +11,16 @@ $ const { id, pageNode } = data;
     </marko-web-gtm-magazine-issue-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
+      <@section|{ aliases }|>
+        <global-gam-define-display-ad
+          name="rotation"
+          position="magazine_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
+
       <@section>
         <div class="row">
           <div class="col">

--- a/packages/global/templates/magazine/publication.marko
+++ b/packages/global/templates/magazine/publication.marko
@@ -1,6 +1,6 @@
 import issueFragment from "../../graphql/fragments/magazine-issue-archive";
 
-$ const { GAM, pagination: p, req } = out.global;
+$ const { pagination: p, req } = out.global;
 $ const { id, pageNode } = data;
 $ const perPage = 16;
 
@@ -11,8 +11,16 @@ $ const perPage = 16;
     </marko-web-gtm-magazine-publication-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper>
+      <@section|{ aliases }|>
+        <global-gam-define-display-ad
+          name="rotation"
+          position="magazine_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </@section>
+
       <@section>
         <div class="row">
           <div class="col">

--- a/packages/global/templates/magazine/publication.marko
+++ b/packages/global/templates/magazine/publication.marko
@@ -2,7 +2,7 @@ import issueFragment from "../../graphql/fragments/magazine-issue-archive";
 
 $ const { GAM, pagination: p, req } = out.global;
 $ const { id, pageNode } = data;
-$ const perPage = 4;
+$ const perPage = 16;
 
 <marko-web-magazine-publication-page-layout id=id>
   <@head>

--- a/packages/global/templates/magazine/publication.marko
+++ b/packages/global/templates/magazine/publication.marko
@@ -44,7 +44,7 @@ $ const perPage = 16;
             name="magazine-active-issues"
             params=params
           >
-            <global-magazine-issue-archive-flow nodes=nodes />
+            <global-magazine-issue-archive-flow nodes=nodes flush=true />
           </marko-web-query>
           <div class="mb-block">
             <global-query-total-count|{ totalCount }| name="magazine-active-issues" params={publicationId: id}>

--- a/packages/global/templates/magazine/publication.marko
+++ b/packages/global/templates/magazine/publication.marko
@@ -1,0 +1,62 @@
+import issueFragment from "../../graphql/fragments/magazine-issue-archive";
+
+$ const { GAM, pagination: p, req } = out.global;
+$ const { id, pageNode } = data;
+$ const perPage = 4;
+
+<marko-web-magazine-publication-page-layout id=id>
+  <@head>
+    <marko-web-gtm-magazine-publication-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-magazine-publication-context>
+  </@head>
+  <@page>
+    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "leaderboard" }) modifiers=["top-of-page"] />
+    <marko-web-page-wrapper>
+      <@section>
+        <div class="row">
+          <div class="col">
+            <marko-web-resolve-page|{ data: publication }| node=pageNode>
+              <default-theme-breadcrumbs-with-home>
+                <@item><marko-web-link href="/magazine">Magazines</marko-web-link></@item>
+                <@item><marko-web-magazine-publication-name tag=null obj=publication /></@item>
+              </default-theme-breadcrumbs-with-home>
+              <h1 class="page-wrapper__title">
+                ${publication.name} Issue Archive
+                <if(p.page > 1)>: Page ${p.page}</if>
+              </h1>
+              <if(publication.description)>
+                <p class="page-wrapper__deck">${publication.description}</p>
+              </if>
+            </marko-web-resolve-page>
+          </div>
+        </div>
+      </@section>
+      <@section>
+        <marko-web-resolve-page|{ data: publication }| node=pageNode>
+          $ const params = {
+            publicationId: id,
+            limit: perPage,
+            skip:p.skip({ perPage }),
+            queryFragment: issueFragment,
+          };
+          <marko-web-query|{ nodes }|
+            name="magazine-active-issues"
+            params=params
+          >
+            <global-magazine-issue-archive-flow nodes=nodes />
+          </marko-web-query>
+          <div class="mb-block">
+            <global-query-total-count|{ totalCount }| name="magazine-active-issues" params={publicationId: id}>
+              <global-pagination-controls
+                per-page=perPage
+                total-count=totalCount
+                path=req.path
+              />
+            </global-query-total-count>
+          </div>
+        </marko-web-resolve-page>
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-magazine-publication-page-layout>


### PR DESCRIPTION
I left the home page as is, but when you want to add this to the home page you will need the following:
```
import latestIssueFragment from "@cox-matthews-associates/package-global/graphql/fragments/magazine-latest-issue";

      <div class="col-lg-4 mb-block">
        <marko-web-query|{ node: issue }|
          name="magazine-latest-issue"
          params={ publicationId: "61128276dc429e5a098b4576", queryFragment: latestIssueFragment, requiresImage: true  }
        >
          <global-magazine-latest-issue-flow issue-node=issue>
            <@header>
              <marko-web-magazine-issue-name tag=null obj=issue link=true>
                In Print
              </marko-web-magazine-issue-name>
            </@header>
          </global-magazine-latest-issue-flow>
        </marko-web-query>
      </div>
```
      

### Homepage block:
<img width="1176" alt="Screen Shot 2021-08-11 at 8 24 07 AM" src="https://user-images.githubusercontent.com/3845869/129037642-b07a09b8-fcec-4d34-a879-6dc4534590eb.png">
      
### Publication Landing Page:
<img width="1163" alt="Screen Shot 2021-08-11 at 8 44 53 AM" src="https://user-images.githubusercontent.com/3845869/129040405-eec3ce5f-2267-464d-a694-56f2abda5e80.png">

### Issue Landing Page:
<img width="1183" alt="Screen Shot 2021-08-11 at 8 55 55 AM" src="https://user-images.githubusercontent.com/3845869/129042165-1be65b2c-b90f-429b-9aa5-8180b6a9c3e7.png">



### /magazine landing page:
<img width="1257" alt="Screen Shot 2021-08-11 at 8 55 47 AM" src="https://user-images.githubusercontent.com/3845869/129042048-d913f35d-c10d-41b5-8f78-204456e837a7.png">


