### PR TITLE
Add styles to override included style tag from esurvey

### DIFF
--- a/packages/global/components/blocks/esurveypro.marko
+++ b/packages/global/components/blocks/esurveypro.marko
@@ -1,4 +1,4 @@
-<div class="node-list node-list--section-list node-list--esurveypro node-list--flush-x node-list--flush-y">
+<div class="node-list node-list--section-list node-list--esurveypro node-list--flush-x node-list--flush-y node-list--inner-justified">
   <marko-web-element block-name="node-list" name="header">
     Diverse Poll
   </marko-web-element>

--- a/packages/global/components/blocks/esurveypro.marko
+++ b/packages/global/components/blocks/esurveypro.marko
@@ -1,4 +1,4 @@
-<div class="node-list node-list--section-list node-list--esurveypro node-list--flush-y">
+<div class="node-list node-list--section-list node-list--esurveypro node-list--flush-x node-list--flush-y">
   <marko-web-element block-name="node-list" name="header">
     Diverse Poll
   </marko-web-element>

--- a/packages/global/scss/components/blocks/_esurveypro.scss
+++ b/packages/global/scss/components/blocks/_esurveypro.scss
@@ -32,6 +32,7 @@
 }
 
 .ESP {
+  $self: &;
   &-box {
     width: 100% !important;
     margin: 0 !important;
@@ -41,6 +42,9 @@
     .radio,
     input[type="radio"] {
       margin-left: initial !important;
+    }
+    label[class^="#{ $self }-answer"] {
+      width: clac(100% - 10px);
     }
   }
   &-question-top {

--- a/packages/global/scss/components/blocks/_esurveypro.scss
+++ b/packages/global/scss/components/blocks/_esurveypro.scss
@@ -9,6 +9,27 @@
 }
 
 // Specific overrides to css file being imported with script.
+.node-list--inner-justified {
+  div[id^="ESP_container"] {
+    height: 100%;
+  }
+  .ESP {
+    &-box,
+    &-box-outer,
+    &-box-inner,
+    &-box-top {
+      height: 100% !important;
+    }
+    &-box-top {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+    &-answer {
+      flex-grow: 1;
+    }
+  }
+}
 
 .ESP {
   &-box {

--- a/packages/global/scss/components/blocks/_esurveypro.scss
+++ b/packages/global/scss/components/blocks/_esurveypro.scss
@@ -11,6 +11,7 @@
 // Specific overrides to css file being imported with script.
 .node-list--inner-justified {
   div[id^="ESP_container"] {
+    width: 100%;
     height: 100%;
   }
   .ESP {
@@ -32,7 +33,6 @@
 }
 
 .ESP {
-  $self: &;
   &-box {
     width: 100% !important;
     margin: 0 !important;
@@ -43,8 +43,8 @@
     input[type="radio"] {
       margin-left: initial !important;
     }
-    label[class^="#{ $self }-answer"] {
-      width: clac(100% - 10px);
+    label[class^="ESP-answer"] {
+      width: calc(100% - 10px);
     }
   }
   &-question-top {

--- a/packages/global/scss/components/blocks/_esurveypro.scss
+++ b/packages/global/scss/components/blocks/_esurveypro.scss
@@ -7,3 +7,54 @@
     }
   }
 }
+
+// Specific overrides to css file being imported with script.
+
+.ESP {
+  &-box {
+    width: 100% !important;
+    margin: 0 !important;
+  }
+  &-answer {
+    width: calc(100% - 30px) !important;
+    .radio,
+    input[type="radio"] {
+      margin-left: initial !important;
+    }
+  }
+  &-question-top {
+    padding-top: $block-spacer / 2;
+    padding-bottom: $block-spacer / 2;
+    margin: ($block-spacer / 2) 0 !important;
+    font-family: $skin-font-family-primary !important;
+    font-size: 17px !important;
+    font-weight: $font-weight-semibold !important;
+    line-height: 1.25 !important;
+    color: $gray-800 !important;
+    letter-spacing: inherit !important;
+  }
+  &-votebutton-outer {
+    margin-top: $block-spacer;
+    @include marko-web-node-list-border(border-top);
+  }
+
+  &-viewResult,
+  &-votebutton {
+    width: auto !important;
+    height: auto !important;
+    padding: 12px !important;
+    margin-top: ($block-spacer / 2) !important;
+    font-family: $skin-font-family-primary !important;
+    font-size: 12px !important;
+    font-weight: $font-weight-bold !important;
+    line-height: 1.25 !important;
+    color: #fff !important;
+    text-align: center !important;
+    text-transform: uppercase !important;
+    letter-spacing: .8px !important;
+    vertical-align: middle !important;
+    background-color: #436daa !important;
+    border: none !important;
+    border-radius: 4px !important;
+  }
+}


### PR DESCRIPTION
Add flush-x and add !important style overrides for eSurvey poll block

<img width="1158" alt="Screen Shot 2021-08-11 at 11 15 48 AM" src="https://user-images.githubusercontent.com/3845869/129065621-2918224f-0df5-41f8-a5d4-2e3d3cb38d9a.png">

