### PR TITLE
Add support for query all website scheduled content sorted by startDate Desc, specifically for /webinars & event/diverse-live-talk.

### DIFF
--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -111,7 +111,8 @@
     "<node>": {},
     "@alias": "string",
     "@count-only": "boolean",
-    "@display-image": "boolean"
+    "@display-image": "boolean",
+    "@with-section": "boolean"
   },
   "<global-section-cards-block>": {
     "template": "./section-cards.marko",

--- a/packages/global/components/blocks/section-feed.marko
+++ b/packages/global/components/blocks/section-feed.marko
@@ -1,7 +1,6 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import queryFragment from "../../graphql/fragments/section-feed-block";
 
-$ const queryName = defaultValue(input.queryName, "website-scheduled-content");
 $ const withSection = defaultValue(input.withSection, true);
 $ const queryParams = {
   ...input.queryParams,
@@ -13,12 +12,12 @@ $ const blockName = "section-feed";
 $ const countOnly = defaultValue(input.countOnly, false);
 
 <if(countOnly)>
-  <global-query-total-count|data| name=queryName params=queryParams>
+  <global-query-total-count|data| name="website-scheduled-content" params=queryParams>
     <${input.renderBody} ...data />
   </global-query-total-count>
 </if>
 <else>
-  <marko-web-query|{ nodes }| name=queryName params=queryParams>
+  <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
     <marko-web-node-list
       inner-justified=true
       flush-x=true

--- a/packages/global/components/blocks/section-feed.marko
+++ b/packages/global/components/blocks/section-feed.marko
@@ -8,7 +8,6 @@ $ const queryParams = {
   queryFragment,
 };
 
-$ console.log(queryName, queryParams);
 $ const blockName = "section-feed";
 $ const countOnly = defaultValue(input.countOnly, false);
 

--- a/packages/global/components/blocks/section-feed.marko
+++ b/packages/global/components/blocks/section-feed.marko
@@ -1,22 +1,24 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import queryFragment from "../../graphql/fragments/section-feed-block";
 
+$ const queryName = defaultValue(input.queryName, "website-scheduled-content");
 $ const queryParams = {
   ...input.queryParams,
-  sectionAlias: input.alias,
+  ...(input.alias && { sectionAlias: input.alias}),
   queryFragment,
 };
 
+$ console.log(queryName, queryParams);
 $ const blockName = "section-feed";
 $ const countOnly = defaultValue(input.countOnly, false);
 
 <if(countOnly)>
-  <global-query-total-count|data| name="website-scheduled-content" params=queryParams>
+  <global-query-total-count|data| name=queryName params=queryParams>
     <${input.renderBody} ...data />
   </global-query-total-count>
 </if>
 <else>
-  <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
+  <marko-web-query|{ nodes }| name=queryName params=queryParams>
     <marko-web-node-list
       inner-justified=true
       flush-x=true

--- a/packages/global/components/blocks/section-feed.marko
+++ b/packages/global/components/blocks/section-feed.marko
@@ -2,6 +2,7 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import queryFragment from "../../graphql/fragments/section-feed-block";
 
 $ const queryName = defaultValue(input.queryName, "website-scheduled-content");
+$ const withSection = defaultValue(input.withSection, true);
 $ const queryParams = {
   ...input.queryParams,
   ...(input.alias && { sectionAlias: input.alias}),
@@ -26,7 +27,11 @@ $ const countOnly = defaultValue(input.countOnly, false);
     >
       <@nodes nodes=nodes>
         <@slot|{ node }|>
-          <global-section-feed-content-node node=node display-image=input.displayImage />
+          <global-section-feed-content-node
+            node=node
+            display-image=input.displayImage
+            with-section=withSection
+          />
         </@slot>
       </@nodes>
     </marko-web-node-list>

--- a/packages/global/components/blocks/section-feed.marko
+++ b/packages/global/components/blocks/section-feed.marko
@@ -4,7 +4,7 @@ import queryFragment from "../../graphql/fragments/section-feed-block";
 $ const withSection = defaultValue(input.withSection, true);
 $ const queryParams = {
   ...input.queryParams,
-  ...(input.alias && { sectionAlias: input.alias}),
+  sectionAlias: input.alias,
   queryFragment,
 };
 

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -162,6 +162,16 @@ $ const excludeFromSidebarsLabel = ["Scholar Profile"];
           </default-theme-content-download>
         </if>
 
+        <if(type === "webinar")>
+          <div class="mb-block" >
+            $ const isUpcoming = content.startDate > Date.now();
+            <default-theme-content-link-url
+              obj=content
+              label=(isUpcoming ? "Register for Webinar" : "View Webinar")
+              target="_blank"
+            />
+          </div>
+        </if>
         <!-- <if(displayNewsletterSignup)>
           <global-newsletter-signup-banner-block />
         </if> -->

--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -29,6 +29,16 @@
     "@page-node": "object",
     "@display-image": "boolean"
   },
+  "<global-website-section-upcoming-archive-feed-layout>": {
+    "template": "./upcoming-archive-feed.marko",
+    "@sections <section>[]": {},
+    "<before-name>": {},
+    "<after-name>": {},
+    "@id": "number",
+    "@alias": "string",
+    "@name": "string",
+    "@page-node": "object"
+  },
   "<global-website-section-home-layout>": {
     "template": "./home.marko",
     "<head>": {},

--- a/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
@@ -6,14 +6,14 @@ $ const sections = getAsArray(input, "sections");
 
 $ const queryParams = {
   includeContentTypes: ["Webinar"],
-  sectionId: id,
+  sectionAlias: alias,
   sectionBubbling: false,
   sort: {
     field: "startDate",
-    order: "asc",
+    order: "desc",
   },
 };
-
+$ console.log(queryParams);
 $ const { pagination: p } = out.global;
 $ const perPage = 18;
 
@@ -26,7 +26,7 @@ $ const perPage = 18;
   <@head>
     <global-section-feed-block|{ totalCount }|
       count-only=true
-      query-name="all-published-content"
+      query-name="website-scheduled-content"
     >
       <@query-params ...queryParams />
       <global-pagination-controls
@@ -69,7 +69,7 @@ $ const perPage = 18;
       />
     </if>
 
-    <global-section-feed-block query-name="all-published-content" with-section=false >
+    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
       <@query-params ...queryParams limit=3 skip=p.skip({ perPage }) />
     </global-section-feed-block>
   </@section>
@@ -84,7 +84,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="all-published-content" with-section=false >
+    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
       <@query-params ...queryParams limit=2 skip=p.skip({ perPage, skip: 3 }) />
     </global-section-feed-block>
   </@section>
@@ -94,7 +94,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="all-published-content" with-section=false >
+    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
       <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 5 }) />
     </global-section-feed-block>
   </@section>
@@ -109,7 +109,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="all-published-content" with-section=false >
+    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
       <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 8 }) />
     </global-section-feed-block>
   </@section>
@@ -124,12 +124,12 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="all-published-content" with-section=false >
+    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
       <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 13 }) />
     </global-section-feed-block>
     <global-section-feed-block|{ totalCount }|
       count-only=true
-      query-name="all-published-content"
+      query-name="website-scheduled-content"
     >
       <@query-params ...queryParams />
       <global-pagination-controls

--- a/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
@@ -69,7 +69,7 @@ $ const perPage = 18;
       />
     </if>
 
-    <global-section-feed-block query-name="all-published-content">
+    <global-section-feed-block query-name="all-published-content" with-section=false >
       <@query-params ...queryParams limit=3 skip=p.skip({ perPage }) />
     </global-section-feed-block>
   </@section>
@@ -84,7 +84,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="all-published-content">
+    <global-section-feed-block query-name="all-published-content" with-section=false >
       <@query-params ...queryParams limit=2 skip=p.skip({ perPage, skip: 3 }) />
     </global-section-feed-block>
   </@section>
@@ -94,7 +94,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="all-published-content">
+    <global-section-feed-block query-name="all-published-content" with-section=false >
       <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 5 }) />
     </global-section-feed-block>
   </@section>
@@ -109,7 +109,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="all-published-content">
+    <global-section-feed-block query-name="all-published-content" with-section=false >
       <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 8 }) />
     </global-section-feed-block>
   </@section>
@@ -124,7 +124,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="all-published-content">
+    <global-section-feed-block query-name="all-published-content" with-section=false >
       <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 13 }) />
     </global-section-feed-block>
     <global-section-feed-block|{ totalCount }|

--- a/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
@@ -6,7 +6,6 @@ $ const sections = getAsArray(input, "sections");
 
 $ const queryParams = {
   includeContentTypes: ["Webinar"],
-  sectionAlias: alias,
   sectionBubbling: false,
   sort: {
     field: "startDate",
@@ -23,7 +22,7 @@ $ const perPage = 18;
   page-node=pageNode
 >
   <@head>
-    <global-section-feed-block|{ totalCount }| count-only=true >
+    <global-section-feed-block|{ totalCount }| count-only=true alias=alias >
       <@query-params ...queryParams />
       <global-pagination-controls
         per-page=perPage
@@ -65,7 +64,7 @@ $ const perPage = 18;
       />
     </if>
 
-    <global-section-feed-block with-section=false >
+    <global-section-feed-block with-section=false alias=alias >
       <@query-params ...queryParams limit=3 skip=p.skip({ perPage }) />
     </global-section-feed-block>
   </@section>
@@ -80,7 +79,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block with-section=false >
+    <global-section-feed-block with-section=false alias=alias >
       <@query-params ...queryParams limit=2 skip=p.skip({ perPage, skip: 3 }) />
     </global-section-feed-block>
   </@section>
@@ -90,7 +89,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block with-section=false >
+    <global-section-feed-block with-section=false alias=alias >
       <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 5 }) />
     </global-section-feed-block>
   </@section>
@@ -105,7 +104,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block with-section=false >
+    <global-section-feed-block with-section=false alias=alias >
       <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 8 }) />
     </global-section-feed-block>
   </@section>
@@ -120,10 +119,10 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block with-section=false >
+    <global-section-feed-block with-section=false alias=alias >
       <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 13 }) />
     </global-section-feed-block>
-    <global-section-feed-block|{ totalCount }| count-only=true >
+    <global-section-feed-block|{ totalCount }| count-only=true alias=alias >
       <@query-params ...queryParams />
       <global-pagination-controls
         per-page=perPage

--- a/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
@@ -24,10 +24,7 @@ $ const perPage = 18;
   page-node=pageNode
 >
   <@head>
-    <global-section-feed-block|{ totalCount }|
-      count-only=true
-      query-name="website-scheduled-content"
-    >
+    <global-section-feed-block|{ totalCount }| count-only=true >
       <@query-params ...queryParams />
       <global-pagination-controls
         per-page=perPage
@@ -69,7 +66,7 @@ $ const perPage = 18;
       />
     </if>
 
-    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
+    <global-section-feed-block with-section=false >
       <@query-params ...queryParams limit=3 skip=p.skip({ perPage }) />
     </global-section-feed-block>
   </@section>
@@ -84,7 +81,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
+    <global-section-feed-block with-section=false >
       <@query-params ...queryParams limit=2 skip=p.skip({ perPage, skip: 3 }) />
     </global-section-feed-block>
   </@section>
@@ -94,7 +91,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
+    <global-section-feed-block with-section=false >
       <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 5 }) />
     </global-section-feed-block>
   </@section>
@@ -109,7 +106,7 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
+    <global-section-feed-block with-section=false >
       <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 8 }) />
     </global-section-feed-block>
   </@section>
@@ -124,13 +121,10 @@ $ const perPage = 18;
   </@section>
 
   <@section>
-    <global-section-feed-block query-name="website-scheduled-content" with-section=false >
+    <global-section-feed-block with-section=false >
       <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 13 }) />
     </global-section-feed-block>
-    <global-section-feed-block|{ totalCount }|
-      count-only=true
-      query-name="website-scheduled-content"
-    >
+    <global-section-feed-block|{ totalCount }| count-only=true >
       <@query-params ...queryParams />
       <global-pagination-controls
         per-page=perPage

--- a/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
@@ -1,0 +1,165 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+$ const now = Date.now();
+
+$ const { id, alias, name, pageNode } = input;
+$ const sections = getAsArray(input, "sections");
+
+$ const queryParams = {
+  includeContentTypes: ["Webinar"],
+  sectionId: id,
+  sectionBubbling: false,
+  sort: {
+    field: "startDate",
+    order: "asc",
+  },
+};
+
+$ const { pagination: p } = out.global;
+$ const perPage = 18;
+
+<global-website-section-default-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+>
+  <@head>
+    <global-section-feed-block|{ totalCount }|
+      count-only=true
+      query-name="all-published-content"
+    >
+      <@query-params ...queryParams />
+      <global-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+        as-rels=true
+      />
+    </global-section-feed-block>
+  </@head>
+
+  <@section|{ aliases }| modifiers=["first"]>
+    <global-gam-define-display-ad
+      name="leaderboard"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section|{ blockName, section, aliases }|>
+    <if(input.beforeName)>
+      <${input.beforeName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+
+    <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
+      <if(p.page > 1)>${value}: Page ${p.page}</if>
+      <else>${value}</else>
+    </marko-web-website-section-name>
+
+    <if(input.afterName)>
+      <${input.afterName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+
+    <global-section-feed-block query-name="all-published-content">
+      <@query-params ...queryParams limit=3 skip=p.skip({ perPage }) />
+    </global-section-feed-block>
+  </@section>
+
+  <@section|{ aliases }|>
+    <global-gam-define-display-ad
+      name="rotation"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section>
+    <global-section-feed-block query-name="all-published-content">
+      <@query-params ...queryParams limit=2 skip=p.skip({ perPage, skip: 3 }) />
+    </global-section-feed-block>
+  </@section>
+
+  <@section>
+    <global-newsletter-signup-banner-large-block />
+  </@section>
+
+  <@section>
+    <global-section-feed-block query-name="all-published-content">
+      <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 5 }) />
+    </global-section-feed-block>
+  </@section>
+
+  <@section|{ aliases }|>
+    <global-gam-define-display-ad
+      name="rotation"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section>
+    <global-section-feed-block query-name="all-published-content">
+      <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 8 }) />
+    </global-section-feed-block>
+  </@section>
+
+  <@section|{ aliases }|>
+    <global-gam-define-display-ad
+      name="rotation"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section>
+    <global-section-feed-block query-name="all-published-content">
+      <@query-params ...queryParams limit=5 skip=p.skip({ perPage, skip: 13 }) />
+    </global-section-feed-block>
+    <global-section-feed-block|{ totalCount }|
+      count-only=true
+      query-name="all-published-content"
+    >
+      <@query-params ...queryParams />
+      <global-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+      />
+    </global-section-feed-block>
+  </@section>
+
+  <@section>
+    <global-top-stories-block />
+  </@section>
+
+  <for|s| of=sections>
+    <@section|{ blockName, section, aliases }| modifiers=s.modifiers>
+      <${s.renderBody}
+        block-name=blockName
+        section=section
+        aliases=aliases
+      />
+    </@section>
+  </for>
+
+  <@section|{ aliases }|>
+    <global-gam-define-display-ad
+      name="rotation"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+</global-website-section-default-layout>

--- a/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
@@ -13,7 +13,6 @@ $ const queryParams = {
     order: "desc",
   },
 };
-$ console.log(queryParams);
 $ const { pagination: p } = out.global;
 $ const perPage = 18;
 

--- a/packages/global/components/nodes/section-feed-content.marko
+++ b/packages/global/components/nodes/section-feed-content.marko
@@ -54,11 +54,9 @@ $ const blockName = "section-feed-content-node";
         />
       </if>
       <if(withDates && content.startDate)>
-        <marko-web-content-start-date
-          block-name=blockName
-          obj=content
-          format="MMMM D, YYYY"
-        />
+        <div class=`${blockName}__content-event-dates`>
+          <marko-web-content-start-date tag="span" block-name=blockName obj=content />
+        </div>
         <if(content.linkUrl)>
           <default-theme-content-link-url
             obj=content

--- a/packages/global/components/nodes/section-feed-content.marko
+++ b/packages/global/components/nodes/section-feed-content.marko
@@ -10,6 +10,7 @@ $ const linkAttrs = getAsObject(input, "linkAttrs");
 
 $ const withBody = defaultValue(input.withBody, false);
 $ const withDates = defaultValue(input.withDates, true);
+$ const isUpcoming = content.startDate > Date.now();
 $ const withSection = defaultValue(input.withSection, true);
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const displayImage = defaultValue(input.displayImage, true);
@@ -52,13 +53,27 @@ $ const blockName = "section-feed-content-node";
           obj=content
         />
       </if>
-      <if(withDates)>
+      <if(withDates && content.startDate)>
+        <marko-web-content-start-date
+          block-name=blockName
+          obj=content
+          format="MMMM D, YYYY"
+        />
+        <if(content.linkUrl)>
+          <default-theme-content-link-url
+            obj=content
+            label=(isUpcoming ? "Register for Webinar" : "View Webinar")
+            target="_blank"
+          />
+        </if>
+      </if>
+      <else-if(withDates)>
         <marko-web-content-published
           block-name=blockName
           obj=content
           format="MMMM D, YYYY"
         />
-      </if>
+      </else-if>
     </marko-web-element>
   </marko-web-element>
   <if(displayImage)>

--- a/packages/global/graphql/fragments/section-feed-block.js
+++ b/packages/global/graphql/fragments/section-feed-block.js
@@ -12,6 +12,10 @@ fragment SectionFeedBlockContentFragment on Content {
     path
   }
   published
+  ... on ContentWebinar {
+    linkUrl
+    startDate
+  }
   primarySection {
     id
     name

--- a/packages/global/scss/components/_content-page.scss
+++ b/packages/global/scss/components/_content-page.scss
@@ -24,6 +24,9 @@
   max-width: $skin-content-body-max-width;
   margin-right: auto;
   margin-left: auto;
+  video {
+    max-width: 100%;
+  }
 }
 
 .content-page-header {

--- a/packages/global/scss/components/blocks/_section-feed.scss
+++ b/packages/global/scss/components/blocks/_section-feed.scss
@@ -74,6 +74,21 @@
     }
   }
 
+  &__content-event-dates {
+    margin-top: 10px;
+    @include skin-typography($style: "teaser-text-1", $link-style: "primary", $breakpoint: sm);
+  }
+  &__content-start-date {
+    &::before {
+      font-weight: $font-weight-bold;
+      content: "Date: ";
+    }
+  }
+
+  .btn-primary {
+    margin-top: 10px;
+  }
+
   &__content-published {
     margin-top: 10px;
     @include skin-typography($style: "date");

--- a/sites/diverseeducation.com/server/routes/website-section.js
+++ b/sites/diverseeducation.com/server/routes/website-section.js
@@ -4,6 +4,7 @@ const cards = require('../templates/website-section/cards');
 const podcasts = require('../templates/website-section/podcasts');
 const products = require('../templates/website-section/products');
 const section = require('../templates/website-section');
+const webinars = require('../templates/website-section/webinars');
 
 module.exports = (app) => {
   app.get('/:alias(opinion)', withWebsiteSection({
@@ -16,6 +17,10 @@ module.exports = (app) => {
   }));
   app.get('/:alias(products)', withWebsiteSection({
     template: products,
+    queryFragment,
+  }));
+  app.get('/:alias(webinars)', withWebsiteSection({
+    template: webinars,
     queryFragment,
   }));
   app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({

--- a/sites/diverseeducation.com/server/routes/website-section.js
+++ b/sites/diverseeducation.com/server/routes/website-section.js
@@ -19,7 +19,7 @@ module.exports = (app) => {
     template: products,
     queryFragment,
   }));
-  app.get('/:alias(webinars)', withWebsiteSection({
+  app.get('/:alias(webinars|events/diverse-talk-live)', withWebsiteSection({
     template: webinars,
     queryFragment,
   }));

--- a/sites/diverseeducation.com/server/templates/website-section/webinars.marko
+++ b/sites/diverseeducation.com/server/templates/website-section/webinars.marko
@@ -1,0 +1,12 @@
+$ const { id, alias, name, pageNode } = input;
+
+<global-website-section-upcoming-archive-feed-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+>
+  <@section>
+    <global-client-side-most-popular-block />
+  </@section>
+</global-website-section-upcoming-archive-feed-layout>


### PR DESCRIPTION
https://trello.com/c/wj4kLAlC/80-webcasts

At the moment I have it pulling all published webinars sorted by start date.  This would naturally pull upcoming/future webinars to the top of the list and switch the button text between `View Webinar` & `Register for Webinar`.  The would eliminate the need for upcoming vs archived.  

![webiars-landing-page](https://user-images.githubusercontent.com/3845869/131678402-35dab3bd-a906-4fb1-9969-b0bc2cfa01e1.jpeg)


<img width="1270" alt="Screen Shot 2021-09-01 at 8 18 20 AM" src="https://user-images.githubusercontent.com/3845869/131678329-68f13c29-6089-4be5-b946-e54ad998cf93.png">


