### PR TITLE
Create new site header/navbar

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -69,7 +69,7 @@ $ const {
     <marko-web-gam-targeting key-values={ uri: req.path } />
   </@head>
   <@above-container>
-    <if('navbar2' === site.get("navigation.type"))>
+    <if("navbar2" === site.get("navigation.type"))>
       <global-site-header-2 has-user=false reg-enabled=false />
     </if>
     <else>

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -69,7 +69,12 @@ $ const {
     <marko-web-gam-targeting key-values={ uri: req.path } />
   </@head>
   <@above-container>
-    <global-site-header has-user=false reg-enabled=false />
+    <if('navbar2' === site.get("navigation.type"))>
+      <global-site-header-2 has-user=false reg-enabled=false />
+    </if>
+    <else>
+      <global-site-header has-user=false reg-enabled=false />
+    </else>
     <global-site-menu has-user=false reg-enabled=false />
     <!-- <global-site-newsletter-menu /> -->
     <${input.aboveContainer} />

--- a/packages/global/components/marko.json
+++ b/packages/global/components/marko.json
@@ -50,6 +50,9 @@
   "<global-site-header>": {
     "template": "./site-header.marko"
   },
+  "<global-site-header-2>": {
+    "template": "./site-header-2.marko"
+  },
   "<global-site-newsletter-menu>": {
     "template": "./site-newsletter-menu.marko"
   },

--- a/packages/global/components/site-header-2.marko
+++ b/packages/global/components/site-header-2.marko
@@ -18,8 +18,8 @@ $ const navigation = {
   <${input.aboveNav} />
 
 
-  <default-theme-site-navbar modifiers=["secondary"]>
-    <marko-web-block class="site-navbar--left" >
+  <default-theme-site-navbar modifiers=["top"]>
+    <div class="col-lg-4 site-navbar__left">
       <marko-web-block class="subscribe-box">
         <a href="/subscribe" title="Diverse Education September 2, 2021" class="subscribe-box--cover-image">
           <marko-web-img
@@ -36,8 +36,17 @@ $ const navigation = {
           </a>
         </marko-web-block>
       </marko-web-block>
-    </marko-web-block>
-    <marko-web-block class="site-navbar--right" >
+    </div>
+    <div class="col-lg-4 site-navbar__center">
+      <default-theme-site-navbar-brand title=`${config.website("name")} Homepage`>
+        <default-theme-site-navbar-logo
+          alt=config.website("name")
+          src=site.get("logos.navbar.src")
+          srcset=site.getAsArray("logos.navbar.srcset").join(",")
+        />
+      </default-theme-site-navbar-brand>
+    </div>
+    <div class="col-lg-4 site-navbar__right">
       <marko-web-link href="/search">
         <button class="btn btn-lg" type="submit" aria-label="Search">
           <marko-web-icon name="search" modifiers=["dark"] />
@@ -50,17 +59,7 @@ $ const navigation = {
         icon-modifiers=["lg"]
         icon-name="three-bars"
       />
-    </marko-web-block>
-  </default-theme-site-navbar>
-
-  <default-theme-site-navbar modifiers=["branding"]>
-    <default-theme-site-navbar-brand title=`${config.website("name")} Homepage`>
-      <default-theme-site-navbar-logo
-        alt=config.website("name")
-        src=site.get("logos.navbar.src")
-        srcset=site.getAsArray("logos.navbar.srcset").join(",")
-      />
-    </default-theme-site-navbar-brand>
+    </div>
   </default-theme-site-navbar>
 
   <default-theme-site-navbar modifiers=["primary"]>

--- a/packages/global/components/site-header-2.marko
+++ b/packages/global/components/site-header-2.marko
@@ -1,3 +1,6 @@
+import shuffle from "../utils/shuffle-array";
+import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+
 $ const { config, site } = out.global;
 
 $ const blockName = input.blockName || "site-header";
@@ -7,6 +10,8 @@ $ const navigation = {
   secondary: site.getAsArray("navigation.secondary.items"),
   tertiary: site.getAsArray("navigation.tertiary.items"),
 };
+$ const promo = shuffle(site.getAsArray("navigation.promos"))[0];
+$ const headerColClass = promo ? "col-lg-4" : "col-lg-6";
 
 <marko-web-block
   name=blockName
@@ -17,27 +22,34 @@ $ const navigation = {
 >
   <${input.aboveNav} />
 
-
   <default-theme-site-navbar modifiers=["top"]>
-    <div class="col-lg-4 site-navbar__left">
-      <marko-web-block class="subscribe-box">
-        <a href="/subscribe" title="Diverse Education September 2, 2021" class="subscribe-box--cover-image">
-          <marko-web-img
-            alt="Diverse Education September 2, 2021"
-            src="https://img.diverseeducation.com/files/base/diverse/all/image/2021/08/September_2__2021.612e87c7a0409.png?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top;"
-            srcset="https://img.diverseeducation.com/files/base/diverse/all/image/2021/08/September_2__2021.612e87c7a0409.png?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top;"
-            lazyload=true
-            class="magazine-cover"
-          />
-        </a>
-        <marko-web-block class="subscribe-box--call-to-action">
-          <a href="/subscribe" title="Diverse Education September 2, 2021" class="btn btn-primary">
-            Subscribe
-          </a>
+    <if(promo)>
+      <div class=`${headerColClass} site-navbar__left`>
+        $ const promoSrc = get(promo, "image.src");
+        $ const promoSrcSet = getAsArray(promo, "image.srcset");
+        <marko-web-block class="subscribe-box">
+          <if(promoSrc)>
+            <a href=promo.link title=`${promo.callToAction} - ${promo.title}` class="subscribe-box--cover-image">
+              <marko-web-img
+                alt=promo.title
+                src=promoSrc
+                srcset=promoSrcSet
+                lazyload=true
+                class="magazine-cover"
+              />
+            </a>
+          </if>
+          <if(promo.callToAction)>
+            <marko-web-block class="subscribe-box--call-to-action">
+              <a href=promo.link title=`${promo.callToAction} - ${promo.title}` class="btn btn-primary">
+                ${promo.callToAction}
+              </a>
+            </marko-web-block>
+          </if>
         </marko-web-block>
-      </marko-web-block>
-    </div>
-    <div class="col-lg-4 site-navbar__center">
+      </div>
+    </if>
+    <div class=`${headerColClass} site-navbar__center`>
       <default-theme-site-navbar-brand title=`${config.website("name")} Homepage`>
         <default-theme-site-navbar-logo
           alt=config.website("name")
@@ -46,7 +58,7 @@ $ const navigation = {
         />
       </default-theme-site-navbar-brand>
     </div>
-    <div class="col-lg-4 site-navbar__right">
+    <div class=`${headerColClass} site-navbar__right`>
       <marko-web-link href="/search">
         <button class="btn btn-lg" type="submit" aria-label="Search">
           <marko-web-icon name="search" modifiers=["dark"] />

--- a/packages/global/components/site-header-2.marko
+++ b/packages/global/components/site-header-2.marko
@@ -1,0 +1,75 @@
+$ const { config, site } = out.global;
+
+$ const blockName = input.blockName || "site-header";
+
+$ const navigation = {
+  primary: site.getAsArray("navigation.primary.items"),
+  secondary: site.getAsArray("navigation.secondary.items"),
+  tertiary: site.getAsArray("navigation.tertiary.items"),
+};
+
+<marko-web-block
+  name=blockName
+  tag=(input.tag || "header")
+  class=input.class
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+  <${input.aboveNav} />
+
+
+  <default-theme-site-navbar modifiers=["secondary"]>
+    <marko-web-block class="site-navbar--left" >
+      <marko-web-block class="subscribe-box">
+        <a href="/subscribe" title="Diverse Education September 2, 2021" class="subscribe-box--cover-image">
+          <marko-web-img
+            alt="Diverse Education September 2, 2021"
+            src="https://img.diverseeducation.com/files/base/diverse/all/image/2021/08/September_2__2021.612e87c7a0409.png?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top;"
+            srcset="https://img.diverseeducation.com/files/base/diverse/all/image/2021/08/September_2__2021.612e87c7a0409.png?auto=format%2Ccompress&amp;fit=crop&amp;h=78&amp;q=70&amp;w=85&amp;crop=top;"
+            lazyload=true
+            class="magazine-cover"
+          />
+        </a>
+        <marko-web-block class="subscribe-box--call-to-action">
+          <a href="/subscribe" title="Diverse Education September 2, 2021" class="btn btn-primary">
+            Subscribe
+          </a>
+        </marko-web-block>
+      </marko-web-block>
+    </marko-web-block>
+    <marko-web-block class="site-navbar--right" >
+      <marko-web-link href="/search">
+        <button class="btn btn-lg" type="submit" aria-label="Search">
+          <marko-web-icon name="search" modifiers=["dark"] />
+        </button>
+      </marko-web-link>
+      <global-menu-toggle-button
+        class="site-navbar__toggler"
+        targets=[".site-menu", "body"]
+        toggle-class="site-menu--open"
+        icon-modifiers=["lg"]
+        icon-name="three-bars"
+      />
+    </marko-web-block>
+  </default-theme-site-navbar>
+
+  <default-theme-site-navbar modifiers=["branding"]>
+    <default-theme-site-navbar-brand title=`${config.website("name")} Homepage`>
+      <default-theme-site-navbar-logo
+        alt=config.website("name")
+        src=site.get("logos.navbar.src")
+        srcset=site.getAsArray("logos.navbar.srcset").join(",")
+      />
+    </default-theme-site-navbar-brand>
+  </default-theme-site-navbar>
+
+  <default-theme-site-navbar modifiers=["primary"]>
+    <default-theme-site-navbar-items
+      items=navigation.primary
+      modifiers=["primary"]
+      reg-enabled=input.regEnabled
+      has-user=input.hasUser
+    />
+  </default-theme-site-navbar>
+  <${input.belowNav} />
+</marko-web-block>

--- a/packages/global/components/site-header-2.marko
+++ b/packages/global/components/site-header-2.marko
@@ -29,7 +29,7 @@ $ const headerColClass = promo ? "col-lg-4" : "col-lg-6";
         $ const promoSrcSet = getAsArray(promo, "image.srcset");
         <marko-web-block class="subscribe-box">
           <if(promoSrc)>
-            <a href=promo.link title=`${promo.callToAction} - ${promo.title}` class="subscribe-box--cover-image">
+            <a href=promo.link title=promo.title class="subscribe-box--cover-image">
               <marko-web-img
                 alt=promo.title
                 src=promoSrc
@@ -41,7 +41,7 @@ $ const headerColClass = promo ? "col-lg-4" : "col-lg-6";
           </if>
           <if(promo.callToAction)>
             <marko-web-block class="subscribe-box--call-to-action">
-              <a href=promo.link title=`${promo.callToAction} - ${promo.title}` class="btn btn-primary">
+              <a href=promo.link title=promo.title class="btn btn-primary">
                 ${promo.callToAction}
               </a>
             </marko-web-block>

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -130,6 +130,9 @@ $font-weight-normal: 400;
 @import "./variables/inputs";
 @import "./variables/typography";
 
+
+$navbarStyle: "navbar" !default;
+
 // Marko Icons
 $marko-web-icon-fill-dark: $gray-800 !default;
 $marko-web-icon-fill-light: $white !default;

--- a/packages/global/scss/components/_site-navbar.scss
+++ b/packages/global/scss/components/_site-navbar.scss
@@ -1,70 +1,72 @@
-.site-navbar {
-  $self: &;
+@if $navbarStyle == "navbar" {
+  .site-navbar {
+    $self: &;
 
-  &__container {
-    max-width: $marko-web-document-container-max-width;
-    @include media-breakpoint-up(xl, $grid-breakpoints) {
+    &__container {
       max-width: $marko-web-document-container-max-width;
-    }
-  }
-
-  &__brand {
-    @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
-      // reduce padding on small logo
-      margin-right: $theme-site-navbar-brand-margin-x / 2;
-      margin-left: $theme-site-navbar-brand-margin-x / 2;
-    }
-  }
-
-  &__logo {
-    filter: none;
-  }
-
-  &__newsletter-toggler {
-    @include theme-toggle-button();
-    padding: 0;
-    margin-top: auto;
-    margin-bottom: auto;
-
-    @media (min-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
-      margin-left: auto;
-    }
-
-    & > .marko-web-icon {
-      @include theme-navbar-link-color($theme-site-navbar-secondary-colors);
-    }
-  }
-
-  &--secondary {
-    #{ $self } {
-      &__container {
-        @media (max-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
-          justify-content: space-between;
-        }
+      @include media-breakpoint-up(xl, $grid-breakpoints) {
+        max-width: $marko-web-document-container-max-width;
       }
     }
-  }
 
-  &__items {
-    text-transform: none;
-
-    &--secondary {
-      @media (max-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
-        display: none;
+    &__brand {
+      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+        // reduce padding on small logo
+        margin-right: $theme-site-navbar-brand-margin-x / 2;
+        margin-left: $theme-site-navbar-brand-margin-x / 2;
       }
+    }
+
+    &__logo {
+      filter: none;
+    }
+
+    &__newsletter-toggler {
+      @include theme-toggle-button();
+      padding: 0;
       margin-top: auto;
       margin-bottom: auto;
 
-      // set letter spacing per design
-      letter-spacing: .5px;
+      @media (min-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
+        margin-left: auto;
+      }
 
+      & > .marko-web-icon {
+        @include theme-navbar-link-color($theme-site-navbar-secondary-colors);
+      }
+    }
+
+    &--secondary {
       #{ $self } {
-        &__link {
-          padding-top: 0;
+        &__container {
+          @media (max-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
+            justify-content: space-between;
+          }
+        }
+      }
+    }
 
-          @media (max-width: map-get($theme-site-header-breakpoints, small-text-secondary)) {
-            padding-right: 8px;
-            padding-left: 8px;
+    &__items {
+      text-transform: none;
+
+      &--secondary {
+        @media (max-width: map-get($theme-site-header-breakpoints, hide-secondary)) {
+          display: none;
+        }
+        margin-top: auto;
+        margin-bottom: auto;
+
+        // set letter spacing per design
+        letter-spacing: .5px;
+
+        #{ $self } {
+          &__link {
+            padding-top: 0;
+
+            @media (max-width: map-get($theme-site-header-breakpoints, small-text-secondary)) {
+              padding-right: 8px;
+              padding-left: 8px;
+            }
           }
         }
       }

--- a/packages/global/scss/components/_site-navbar2.scss
+++ b/packages/global/scss/components/_site-navbar2.scss
@@ -11,24 +11,59 @@
         max-width: $marko-web-document-container-max-width;
       }
     }
-
     &__brand {
+      margin: 0;
+    }
+    &--top {
+      width: 100%;
+      height: 88px;
       @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
-        // reduce padding on small logo
-        margin-right: $theme-site-navbar-brand-margin-x / 2;
-        margin-left: $theme-site-navbar-brand-margin-x / 2;
+        height: 58px;
       }
-    }
-
-    &__logo {
-      filter: none;
-    }
-    &--branding {
-      position: absolute;
-      top: 8px;
-      margin: 0 calc(50% - (295px / 2));
-      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
-        margin-left: 0;
+      padding-top: 10px;
+      background-color: $white;
+      border-bottom: 1px solid $gray-400;
+      #{ $self } {
+        &__left {
+          padding-left: 0;
+          @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+            display: none;
+          }
+        }
+        &__center {
+          align-self: flex-start;
+        }
+        &__right {
+          display: flex;
+          justify-content: flex-end;
+          @media (min-width: map-get($theme-site-header-breakpoints, small-logo)) {
+            padding-right: 0;
+          }
+          .btn,
+          #{ $self }__toggler {
+            width: 40px;
+            height: 40px;
+            padding: 0;
+            margin: 0 0 0 12px;
+            background-color: $gray-100;
+            border-radius: 4px;
+          }
+        }
+      }
+      .subscribe-box {
+        display: flex;
+        &--cover-image {
+          align-self: flex-end;
+        }
+        &--call-to-action {
+          align-self: center;
+          .btn-primary {
+            padding: 8px;
+            margin-left: 16px;
+            font-size: 12px;
+            text-transform: initial;
+          }
+        }
       }
     }
     &--primary {
@@ -47,54 +82,6 @@
           flex-grow: unset;
           padding-right: 0;
           padding-left: 0;
-        }
-      }
-    }
-    &--secondary {
-      height: 88px;
-      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
-        height: 58px;
-      }
-      padding: 0 16px;
-      border-bottom: 1px solid $gray-400;
-      #{ $self }__container {
-        height: 100%;
-        @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
-          justify-content: flex-end;
-        }
-      }
-      #{ $self }--right {
-        .btn,
-        #{ $self }__toggler {
-          width: 40px;
-          height: 40px;
-          padding: 0;
-          margin: 0 0 0 12px;
-          background-color: $gray-100;
-          border-radius: 4px;
-        }
-      }
-    }
-    &--left {
-      display: flex;
-      width: 300px;
-      height: 100%;
-      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
-        display: none;
-      }
-      .btn-primary {
-        padding: 8px;
-        margin-left: 16px;
-        font-size: 12px;
-        text-transform: initial;
-      }
-      .subscribe-box {
-        display: flex;
-        &--cover-image {
-          align-self: flex-end;
-        }
-        &--call-to-action {
-          align-self: center;
         }
       }
     }

--- a/packages/global/scss/components/_site-navbar2.scss
+++ b/packages/global/scss/components/_site-navbar2.scss
@@ -72,6 +72,10 @@
         &__link {
           color: $gray-800;
           text-transform: initial;
+          &--active {
+            font-weight: 700;
+            text-decoration: none;
+          }
         }
         &__items {
           justify-content: space-between;

--- a/packages/global/scss/components/_site-navbar2.scss
+++ b/packages/global/scss/components/_site-navbar2.scss
@@ -5,7 +5,6 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-
       max-width: $marko-web-document-container-max-width;
       @include media-breakpoint-up(xl, $grid-breakpoints) {
         max-width: $marko-web-document-container-max-width;
@@ -16,15 +15,19 @@
     }
     &--top {
       width: 100%;
-      height: 88px;
       @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
         height: 58px;
       }
-      padding-top: 10px;
       background-color: $white;
-      border-bottom: 1px solid $gray-400;
       #{ $self } {
+        &__container {
+          height: $theme-site-navbar-logo-height + 30px;
+          @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+            height: $theme-site-navbar-logo-height-sm + 20px;
+          }
+        }
         &__left {
+          align-self: flex-end;
           padding-left: 0;
           @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
             display: none;
@@ -32,8 +35,13 @@
         }
         &__center {
           display: flex;
-          align-self: flex-start;
-          justify-content: center;
+          @media (min-width: map-get($theme-site-header-breakpoints, small-logo)) {
+            justify-content: center;
+          }
+        }
+        &__center.col-lg-6 {
+          justify-content: flex-start;
+          padding-left: 0;
         }
         &__right {
           display: flex;
@@ -47,6 +55,7 @@
             height: 40px;
             padding: 0;
             margin: 0 0 0 12px;
+            font-size: 1rem;
             background-color: $gray-100;
             border-radius: 4px;
           }
@@ -65,11 +74,24 @@
             font-size: 12px;
             text-transform: initial;
           }
+          &:only-child {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            height: $theme-site-navbar-logo-height + 30px;
+            @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+              height: $theme-site-navbar-logo-height-sm + 20px;
+            }
+            .btn-primary {
+              margin-left: 0;
+            }
+          }
         }
       }
     }
     &--primary {
       background-color: $white;
+      border-top: 1px solid $gray-400;
       #{ $self } {
         &__link {
           color: $gray-800;
@@ -90,6 +112,9 @@
           padding-left: 0;
         }
       }
+    }
+    .magazine-cover {
+      height: 78px;
     }
   }
 }

--- a/packages/global/scss/components/_site-navbar2.scss
+++ b/packages/global/scss/components/_site-navbar2.scss
@@ -31,7 +31,9 @@
           }
         }
         &__center {
+          display: flex;
           align-self: flex-start;
+          justify-content: center;
         }
         &__right {
           display: flex;

--- a/packages/global/scss/components/_site-navbar2.scss
+++ b/packages/global/scss/components/_site-navbar2.scss
@@ -1,0 +1,102 @@
+@if $navbarStyle == "navbar2" {
+  .site-navbar {
+    $self: &;
+    &__container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      max-width: $marko-web-document-container-max-width;
+      @include media-breakpoint-up(xl, $grid-breakpoints) {
+        max-width: $marko-web-document-container-max-width;
+      }
+    }
+
+    &__brand {
+      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+        // reduce padding on small logo
+        margin-right: $theme-site-navbar-brand-margin-x / 2;
+        margin-left: $theme-site-navbar-brand-margin-x / 2;
+      }
+    }
+
+    &__logo {
+      filter: none;
+    }
+    &--branding {
+      position: absolute;
+      top: 8px;
+      margin: 0 calc(50% - (295px / 2));
+      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+        margin-left: 0;
+      }
+    }
+    &--primary {
+      background-color: $white;
+      #{ $self } {
+        &__link {
+          color: $gray-800;
+          text-transform: initial;
+        }
+        &__items {
+          justify-content: space-between;
+        }
+      }
+      .site-navbar {
+        &__item {
+          flex-grow: unset;
+          padding-right: 0;
+          padding-left: 0;
+        }
+      }
+    }
+    &--secondary {
+      height: 88px;
+      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+        height: 58px;
+      }
+      padding: 0 16px;
+      border-bottom: 1px solid $gray-400;
+      #{ $self }__container {
+        height: 100%;
+        @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+          justify-content: flex-end;
+        }
+      }
+      #{ $self }--right {
+        .btn,
+        #{ $self }__toggler {
+          width: 40px;
+          height: 40px;
+          padding: 0;
+          margin: 0 0 0 12px;
+          background-color: $gray-100;
+          border-radius: 4px;
+        }
+      }
+    }
+    &--left {
+      display: flex;
+      width: 300px;
+      height: 100%;
+      @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+        display: none;
+      }
+      .btn-primary {
+        padding: 8px;
+        margin-left: 16px;
+        font-size: 12px;
+        text-transform: initial;
+      }
+      .subscribe-box {
+        display: flex;
+        &--cover-image {
+          align-self: flex-end;
+        }
+        &--call-to-action {
+          align-self: center;
+        }
+      }
+    }
+  }
+}

--- a/packages/global/scss/components/_site-navbar2.scss
+++ b/packages/global/scss/components/_site-navbar2.scss
@@ -83,7 +83,9 @@
               height: $theme-site-navbar-logo-height-sm + 20px;
             }
             .btn-primary {
-              margin-left: 0;
+              @media (min-width: map-get($theme-site-header-breakpoints, hide-primary)) {
+                margin-left: 0;
+              }
             }
           }
         }

--- a/packages/global/scss/components/_site-navbar2.scss
+++ b/packages/global/scss/components/_site-navbar2.scss
@@ -36,7 +36,7 @@
         &__right {
           display: flex;
           justify-content: flex-end;
-          @media (min-width: map-get($theme-site-header-breakpoints, small-logo)) {
+          @media (min-width: map-get($theme-site-header-breakpoints, hide-primary)) {
             padding-right: 0;
           }
           .btn,

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -21,6 +21,7 @@
 @import "./components/podcasts-page";
 @import "./components/site-footer";
 @import "./components/site-menu";
+@import "./components/site-navbar2";
 @import "./components/site-navbar";
 @import "./components/site-newsletter-menu";
 @import "./components/search-page";

--- a/sites/ccnewsnow.com/config/navigation.js
+++ b/sites/ccnewsnow.com/config/navigation.js
@@ -1,3 +1,5 @@
+const subscribe = require('./subscribe');
+
 const topics = [
   { href: '/workforce-development', label: 'Workforce Development' },
   { href: '/leadership', label: 'Leadership' },
@@ -19,7 +21,7 @@ const resources = [
 const utilities = [
   { href: 'https://mediakit.diverseeducation.com/', label: 'Advertise', target: '_blank' },
   { href: '/page/contact-us', label: 'Contact Us' },
-  { href: 'https://responses.diverseeducation.com/CCNewsNow', label: 'Subscribe', target: '_blank' },
+  subscribe,
 ];
 
 const mobileMenu = {
@@ -28,7 +30,7 @@ const mobileMenu = {
     { href: 'https://jobs.ccjobsnow.com', label: 'CC Jobs', target: '_blank' },
   ],
   secondary: [
-    { href: 'https://responses.diverseeducation.com/CCNewsNow', label: 'Subscribe', target: '_blank' },
+    subscribe,
     { href: 'https://mediakit.diverseeducation.com/', label: 'Advertise', target: '_blank' },
   ],
 };
@@ -41,11 +43,21 @@ const desktopMenu = {
 };
 
 module.exports = {
+  type: 'navbar2',
+  promos: [
+    {
+      title: 'Subscribe to Diverse Education',
+      callToAction: 'Subscribe',
+      link: subscribe.href,
+    },
+  ],
   desktopMenu,
   mobileMenu,
   topics,
   primary: {
-    items: [],
+    items: [
+      ...topics,
+    ],
   },
   secondary: {
     items: topics,

--- a/sites/ccnewsnow.com/config/navigation.js
+++ b/sites/ccnewsnow.com/config/navigation.js
@@ -46,8 +46,8 @@ module.exports = {
   type: 'navbar2',
   promos: [
     {
-      title: 'Subscribe to Diverse Education',
-      callToAction: 'Subscribe',
+      title: subscribe.label,
+      callToAction: subscribe.label,
       link: subscribe.href,
     },
   ],

--- a/sites/ccnewsnow.com/config/subscribe.js
+++ b/sites/ccnewsnow.com/config/subscribe.js
@@ -1,0 +1,5 @@
+module.exports = {
+  href: 'https://responses.diverseeducation.com/CCNewsNow',
+  label: 'Subscribe',
+  target: '_blank',
+};

--- a/sites/ccnewsnow.com/server/styles/index.scss
+++ b/sites/ccnewsnow.com/server/styles/index.scss
@@ -1,5 +1,5 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 1200px, // effectively always hide the primary nav
+  hide-primary: 1100px, // effectively always hide the primary nav
   hide-secondary: 700px,
   small-logo: 775px,
   small-text-primary: 0,

--- a/sites/ccnewsnow.com/server/styles/index.scss
+++ b/sites/ccnewsnow.com/server/styles/index.scss
@@ -1,10 +1,13 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 100000px, // effectively always hide the primary nav
+  hide-primary: 1200px, // effectively always hide the primary nav
   hide-secondary: 700px,
   small-logo: 775px,
   small-text-primary: 0,
   small-text-secondary: 830px
 );
+
+$navbarStyle: "navbar2";
+$theme-site-navbar-primary-type: light;
 
 // Colors
 $primary: #436daa;

--- a/sites/diverseeducation.com/config/navigation.js
+++ b/sites/diverseeducation.com/config/navigation.js
@@ -61,8 +61,8 @@ module.exports = {
   type: 'navbar2',
   promos: [
     {
-      title: 'Subscribe to Diverse Education',
-      callToAction: 'Subscribe',
+      title: subscribe.label,
+      callToAction: subscribe.label,
       link: subscribe.href,
     },
   ],

--- a/sites/diverseeducation.com/config/navigation.js
+++ b/sites/diverseeducation.com/config/navigation.js
@@ -1,3 +1,5 @@
+const subscribe = require('./subscribe');
+
 const topics = [
   { href: '/students', label: 'Students' },
   { href: '/faculty-staff', label: 'Faculty & Staff' },
@@ -35,7 +37,7 @@ const awards = [
 const utilities = [
   { href: 'https://mediakit.diverseeducation.com/', label: 'Advertise', target: '_blank' },
   { href: '/page/contact-us', label: 'Contact Us' },
-  { href: '/subscribe', label: 'Subscribe' },
+  subscribe,
 ];
 
 const mobileMenu = {
@@ -43,7 +45,7 @@ const mobileMenu = {
     ...topics,
   ],
   secondary: [
-    { href: '/subscribe', label: 'Subscribe' },
+    subscribe,
     { href: 'https://mediakit.diverseeducation.com/', label: 'Advertise', target: '_blank' },
   ],
 };
@@ -57,6 +59,13 @@ const desktopMenu = {
 
 module.exports = {
   type: 'navbar2',
+  promos: [
+    {
+      title: 'Subscribe to Diverse Education',
+      callToAction: 'Subscribe',
+      link: subscribe.href,
+    },
+  ],
   desktopMenu,
   mobileMenu,
   topics,

--- a/sites/diverseeducation.com/config/navigation.js
+++ b/sites/diverseeducation.com/config/navigation.js
@@ -56,11 +56,12 @@ const desktopMenu = {
 };
 
 module.exports = {
+  type: 'navbar2',
   desktopMenu,
   mobileMenu,
   topics,
   primary: {
-    items: [],
+    items: [...topics],
   },
   secondary: {
     items: [

--- a/sites/diverseeducation.com/config/navigation.js
+++ b/sites/diverseeducation.com/config/navigation.js
@@ -61,7 +61,11 @@ module.exports = {
   mobileMenu,
   topics,
   primary: {
-    items: [...topics],
+    items: [
+      ...topics,
+      { href: '/podcasts', label: 'Podcasts' },
+      { href: '/opinion', label: 'Opinion' },
+    ],
   },
   secondary: {
     items: [

--- a/sites/diverseeducation.com/config/subscribe.js
+++ b/sites/diverseeducation.com/config/subscribe.js
@@ -1,0 +1,4 @@
+module.exports = {
+  href: '/subscribe',
+  label: 'Subscribe',
+};

--- a/sites/diverseeducation.com/server/styles/index.scss
+++ b/sites/diverseeducation.com/server/styles/index.scss
@@ -7,6 +7,7 @@ $theme-site-header-breakpoints: (
 );
 
 $navbarStyle: "navbar2";
+$theme-site-navbar-primary-type: light;
 
 // Colors
 $primary: #436daa;

--- a/sites/diverseeducation.com/server/styles/index.scss
+++ b/sites/diverseeducation.com/server/styles/index.scss
@@ -1,5 +1,5 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 1200px, // effectively always hide the primary nav
+  hide-primary: 1100px, // effectively always hide the primary nav
   hide-secondary: 700px,
   small-logo: 775px,
   small-text-primary: 0,

--- a/sites/diverseeducation.com/server/styles/index.scss
+++ b/sites/diverseeducation.com/server/styles/index.scss
@@ -1,10 +1,12 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 100000px, // effectively always hide the primary nav
+  hide-primary: 1200px, // effectively always hide the primary nav
   hide-secondary: 700px,
   small-logo: 775px,
   small-text-primary: 0,
   small-text-secondary: 830px
 );
+
+$navbarStyle: "navbar2";
 
 // Colors
 $primary: #436daa;

--- a/sites/diversemilitary.net/config/navigation.js
+++ b/sites/diversemilitary.net/config/navigation.js
@@ -1,3 +1,5 @@
+const subscribe = require('./subscribe');
+
 const topics = [
   { href: '/academics', label: 'Academics' },
   { href: '/campus', label: 'Campus' },
@@ -22,7 +24,7 @@ const resources = [
 const utilities = [
   { href: 'https://mediakit.diverseeducation.com/', label: 'Advertise', target: '_blank' },
   { href: '/page/contact-us', label: 'Contact Us' },
-  { href: 'https://responses.diverseeducation.com/DiverseMilitary', label: 'Subscribe', target: '_blank' },
+  subscribe,
 ];
 
 const mobileMenu = {
@@ -30,7 +32,7 @@ const mobileMenu = {
     ...topics,
   ],
   secondary: [
-    { href: 'https://responses.diverseeducation.com/DiverseMilitary', label: 'Subscribe', target: '_blank' },
+    subscribe,
     { href: 'https://mediakit.diverseeducation.com/', label: 'Advertise', target: '_blank' },
   ],
 };
@@ -43,11 +45,21 @@ const desktopMenu = {
 };
 
 module.exports = {
+  type: 'navbar2',
+  promos: [
+    {
+      title: 'Subscribe to Diverse Education',
+      callToAction: 'Subscribe',
+      link: subscribe.href,
+    },
+  ],
   desktopMenu,
   mobileMenu,
   topics,
   primary: {
-    items: [],
+    items: [
+      ...topics,
+    ],
   },
   secondary: {
     items: [

--- a/sites/diversemilitary.net/config/navigation.js
+++ b/sites/diversemilitary.net/config/navigation.js
@@ -48,8 +48,8 @@ module.exports = {
   type: 'navbar2',
   promos: [
     {
-      title: 'Subscribe to Diverse Education',
-      callToAction: 'Subscribe',
+      title: subscribe.label,
+      callToAction: subscribe.label,
       link: subscribe.href,
     },
   ],

--- a/sites/diversemilitary.net/config/subscribe.js
+++ b/sites/diversemilitary.net/config/subscribe.js
@@ -1,0 +1,5 @@
+module.exports = {
+  href: 'https://responses.diverseeducation.com/DiverseMilitary',
+  label: 'Subscribe',
+  target: '_blank',
+};

--- a/sites/diversemilitary.net/server/styles/index.scss
+++ b/sites/diversemilitary.net/server/styles/index.scss
@@ -1,5 +1,5 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 1200px, // effectively always hide the primary nav
+  hide-primary: 1100px, // effectively always hide the primary nav
   hide-secondary: 700px,
   small-logo: 775px,
   small-text-primary: 0,

--- a/sites/diversemilitary.net/server/styles/index.scss
+++ b/sites/diversemilitary.net/server/styles/index.scss
@@ -1,10 +1,13 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 100000px, // effectively always hide the primary nav
+  hide-primary: 1200px, // effectively always hide the primary nav
   hide-secondary: 700px,
   small-logo: 775px,
   small-text-primary: 0,
   small-text-secondary: 830px
 );
+
+$navbarStyle: "navbar2";
+$theme-site-navbar-primary-type: light;
 
 // Colors
 $primary: #436daa;

--- a/sites/divhealth.net/config/navigation.js
+++ b/sites/divhealth.net/config/navigation.js
@@ -58,8 +58,8 @@ module.exports = {
   type: 'navbar2',
   promos: [
     {
-      title: 'Subscribe to Diverse Education',
-      callToAction: 'Subscribe',
+      title: subscribe.label,
+      callToAction: subscribe.label,
       link: subscribe.href,
     },
   ],

--- a/sites/divhealth.net/config/navigation.js
+++ b/sites/divhealth.net/config/navigation.js
@@ -1,3 +1,5 @@
+const subscribe = require('./subscribe');
+
 const topics = [
   { href: '/campus-issues', label: 'Campus Issues' },
   { href: '/disparities', label: 'Disparities' },
@@ -24,15 +26,23 @@ const resources = [
 const utilities = [
   { href: 'https://mediakit.diverseeducation.com/', label: 'Advertise', target: '_blank' },
   { href: '/page/contact-us', label: 'Contact Us' },
-  { href: 'https://responses.diverseeducation.com/DiverseHealth', label: 'Subscribe', target: '_blank' },
+  subscribe,
 ];
 
 const mobileMenu = {
+  type: 'navbar2',
+  promos: [
+    {
+      title: 'Subscribe to Diverse Education',
+      callToAction: 'Subscribe',
+      link: subscribe.href,
+    },
+  ],
   primary: [
     ...topics,
   ],
   secondary: [
-    { href: 'https://responses.diverseeducation.com/DiverseHealth', label: 'Subscribe', target: '_blank' },
+    subscribe,
     { href: 'https://mediakit.diverseeducation.com/', label: 'Advertise', target: '_blank' },
   ],
 };
@@ -45,11 +55,21 @@ const desktopMenu = {
 };
 
 module.exports = {
+  type: 'navbar2',
+  promos: [
+    {
+      title: 'Subscribe to Diverse Education',
+      callToAction: 'Subscribe',
+      link: subscribe.href,
+    },
+  ],
   desktopMenu,
   mobileMenu,
   topics,
   primary: {
-    items: [],
+    items: [
+      ...topics,
+    ],
   },
   secondary: {
     items: [

--- a/sites/divhealth.net/config/subscribe.js
+++ b/sites/divhealth.net/config/subscribe.js
@@ -1,0 +1,5 @@
+module.exports = {
+  href: 'https://responses.diverseeducation.com/DiverseHealth',
+  label: 'Subscribe',
+  target: '_blank',
+};

--- a/sites/divhealth.net/server/styles/index.scss
+++ b/sites/divhealth.net/server/styles/index.scss
@@ -1,5 +1,5 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 1200px, // effectively always hide the primary nav
+  hide-primary: 1100px, // effectively always hide the primary nav
   hide-secondary: 700px,
   small-logo: 775px,
   small-text-primary: 0,

--- a/sites/divhealth.net/server/styles/index.scss
+++ b/sites/divhealth.net/server/styles/index.scss
@@ -1,10 +1,13 @@
 $theme-site-header-breakpoints: (
-  hide-primary: 100000px, // effectively always hide the primary nav
+  hide-primary: 1200px, // effectively always hide the primary nav
   hide-secondary: 700px,
   small-logo: 775px,
   small-text-primary: 0,
   small-text-secondary: 830px
 );
+
+$navbarStyle: "navbar2";
+$theme-site-navbar-primary-type: light;
 
 // Colors
 $primary: #436daa;


### PR DESCRIPTION
This can be turned on for any of the sites.  In navigation.js config you will need to set type: 'sitenav2' & withing the site's index.js the following should be set:

```
$theme-site-header-breakpoints: (
  hide-primary: 1200px, // effectively always hide the primary nav
  hide-secondary: 700px,
  small-logo: 775px,
  small-text-primary: 0,
  small-text-secondary: 830px
);

$navbarStyle: "navbar2";
```

The $navebarStyel & hide-priamary will need to be set/udated

 
<img width="1107" alt="Screen Shot 2021-09-14 at 12 41 40 PM" src="https://user-images.githubusercontent.com/3845869/133309337-0db3726a-325d-4ad8-8787-6a6c273cfd35.png">
<img width="1159" alt="Screen Shot 2021-09-14 at 12 41 50 PM" src="https://user-images.githubusercontent.com/3845869/133309345-8130f4c0-9156-4ac2-9c8f-0ecfc6bd94de.png">
<img width="1130" alt="Screen Shot 2021-09-14 at 12 42 13 PM" src="https://user-images.githubusercontent.com/3845869/133309348-4889f78c-1cc4-4f3e-b87f-449a03525094.png">
<img width="1142" alt="Screen Shot 2021-09-14 at 12 42 20 PM" src="https://user-images.githubusercontent.com/3845869/133309350-6cf60c44-6111-4264-a8e3-caca0cddc3c6.png">
<img width="413" alt="Screen Shot 2021-09-14 at 12 57 15 PM" src="https://user-images.githubusercontent.com/3845869/133309351-810a4751-c2f6-46c7-8a00-804f419e351f.png">
