### PR TITLE
Add ‘Press Releases’ to navigation to show in header and footer

### DIFF
--- a/sites/diverseeducation.com/config/navigation.js
+++ b/sites/diverseeducation.com/config/navigation.js
@@ -36,6 +36,7 @@ const awards = [
 
 const utilities = [
   { href: 'https://mediakit.diverseeducation.com/', label: 'Advertise', target: '_blank' },
+  { href: '/press-releases', label: 'Press Releases' },
   { href: '/page/contact-us', label: 'Contact Us' },
   subscribe,
 ];


### PR DESCRIPTION
Header Menu:
<img width="1151" alt="Screen Shot 2021-10-18 at 10 03 37 AM" src="https://user-images.githubusercontent.com/64623209/137757915-f1334e26-ebb7-4d23-970d-dba4b7434231.png">
Footer:
<img width="1152" alt="Screen Shot 2021-10-18 at 10 04 18 AM" src="https://user-images.githubusercontent.com/64623209/137757957-e65645c9-6080-47d9-8223-2de1f9ad3992.png">

