### PR TITLE
Remove ‘Register Now…’ button on John Hope Franklin page

### DIFF
--- a/sites/diverseeducation.com/server/templates/website-section/john-hope-franklin.marko
+++ b/sites/diverseeducation.com/server/templates/website-section/john-hope-franklin.marko
@@ -53,11 +53,11 @@ $ const queryParams = {
       <else>${value}</else>
     </marko-web-website-section-name>
     <marko-web-website-section-description obj=section tag="p" />
-    <marko-web-block name="register-button">
+    <!-- <marko-web-block name="register-button">
       <a class="btn btn-primary" target="_blank" href="https://responses.diverseeducation.com/2021JHFAwards">
         Register Now for the 2021 Ceremony
       </a>
-    </marko-web-block>
+    </marko-web-block> -->
   </@section>
   <if(p.page === 1)>
     <!-- <@section|{ blockName, section }|>


### PR DESCRIPTION
Live:
<img width="1138" alt="Screen Shot 2021-11-16 at 9 46 21 AM" src="https://user-images.githubusercontent.com/64623209/142017961-67d845fa-f78c-49ec-86af-e9fa2870cc11.png">

Change requested:
<img width="1153" alt="Screen Shot 2021-11-16 at 9 44 26 AM" src="https://user-images.githubusercontent.com/64623209/142017881-c2c67276-a76a-4c47-892e-9b58c4291d87.png">
