### PR TITLE
Update Podcast landing page with new layout and section logo support.

### DIFF
--- a/packages/global/components/layouts/website-section/marko.json
+++ b/packages/global/components/layouts/website-section/marko.json
@@ -29,6 +29,17 @@
     "@page-node": "object",
     "@display-image": "boolean"
   },
+  "<global-website-section-podcast-feed-layout>": {
+    "template": "./podcast-feed.marko",
+    "@sections <section>[]": {},
+    "<before-name>": {},
+    "<after-name>": {},
+    "@id": "number",
+    "@alias": "string",
+    "@name": "string",
+    "@page-node": "object",
+    "@display-image": "boolean"
+  },
   "<global-website-section-upcoming-archive-feed-layout>": {
     "template": "./upcoming-archive-feed.marko",
     "@sections <section>[]": {},

--- a/packages/global/components/layouts/website-section/podcast-feed.marko
+++ b/packages/global/components/layouts/website-section/podcast-feed.marko
@@ -76,6 +76,14 @@ $ const perPage = 10;
         <h1>form</h1>
       </div> -->
     </div>
+
+    <global-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <global-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+      />
+    </global-section-feed-block>
   </@section>
 
   <for|s| of=sections>

--- a/packages/global/components/layouts/website-section/podcast-feed.marko
+++ b/packages/global/components/layouts/website-section/podcast-feed.marko
@@ -67,14 +67,14 @@ $ const perPage = 10;
     </div>
 
     <div class="row">
-      <div class="col col-md-12 podcast-feed">
+      <div class="col col-md-8 podcast-feed">
         <global-section-feed-block alias=alias display-image=false>
           <@query-params limit=perPage skip=p.skip({ perPage }) />
         </global-section-feed-block>
       </div>
-      <!-- <div class="col col-md-4">
-        <h1>form</h1>
-      </div> -->
+      <div class="col col-md-4">
+
+      </div>
     </div>
 
     <global-section-feed-block|{ totalCount }| alias=alias count-only=true>

--- a/packages/global/components/layouts/website-section/podcast-feed.marko
+++ b/packages/global/components/layouts/website-section/podcast-feed.marko
@@ -1,0 +1,99 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const { id, alias, name, pageNode } = input;
+$ const sections = getAsArray(input, "sections");
+
+$ const { pagination: p } = out.global;
+$ const perPage = 10;
+
+<global-website-section-default-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+>
+  <@head>
+    <global-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <global-pagination-controls
+        per-page=perPage
+        total-count=totalCount
+        path=alias
+        as-rels=true
+      />
+    </global-section-feed-block>
+  </@head>
+
+  <@section|{ aliases }| modifiers=["first"]>
+    <global-gam-define-display-ad
+      name="leaderboard"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+
+  <@section|{ blockName, section, aliases }|>
+    <if(input.beforeName)>
+      <${input.beforeName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+
+    <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj=section>
+      <if(p.page > 1)>${value}: Page ${p.page}</if>
+      <else>${value}</else>
+    </marko-web-website-section-name>
+
+    <if(input.afterName)>
+      <${input.afterName}
+        aliases=aliases
+        block-name=blockName
+        section=section
+      />
+    </if>
+    <div class="podcast-logo-description-wrapper">
+      <if(section.logo)>
+        $ const sectionImg = { ...section.logo };
+        <marko-web-img
+          class=`section__logo`
+          src=`${sectionImg.src}?w=150`
+          srcset=[`${sectionImg.src}?w=w=150&dpr=2 2x`]
+          alt="Section Logo"
+        />
+      </if>
+      <marko-web-website-section-description tag="p" obj=section />
+    </div>
+
+    <div class="row">
+      <div class="col col-md-12 podcast-feed">
+        <global-section-feed-block alias=alias display-image=false>
+          <@query-params limit=perPage skip=p.skip({ perPage }) />
+        </global-section-feed-block>
+      </div>
+      <!-- <div class="col col-md-4">
+        <h1>form</h1>
+      </div> -->
+    </div>
+  </@section>
+
+  <for|s| of=sections>
+    <@section|{ blockName, section, aliases }| modifiers=s.modifiers>
+      <${s.renderBody}
+        block-name=blockName
+        section=section
+        aliases=aliases
+      />
+    </@section>
+  </for>
+
+  <@section|{ aliases }|>
+    <global-gam-define-display-ad
+      name="rotation"
+      position="section_page"
+      aliases=aliases
+      modifiers=["inter-block"]
+    />
+  </@section>
+</global-website-section-default-layout>

--- a/packages/global/graphql/fragments/website-section-with-logo-page.js
+++ b/packages/global/graphql/fragments/website-section-with-logo-page.js
@@ -1,7 +1,7 @@
 const gql = require('graphql-tag');
 
 module.exports = gql`
-fragment WebsiteSectionPageFragment on WebsiteSection {
+fragment WebsiteSectionPageWithLogoFragment on WebsiteSection {
   id
   name
   alias

--- a/packages/global/graphql/fragments/website-section-with-logo-page.js
+++ b/packages/global/graphql/fragments/website-section-with-logo-page.js
@@ -1,0 +1,20 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment WebsiteSectionPageFragment on WebsiteSection {
+  id
+  name
+  alias
+  fullName
+  description
+  logo {
+    id
+    src(input: { options: { auto: "format,compress" q: 70 } })
+  }
+  hierarchy {
+    id
+    alias
+    name
+  }
+}
+`;

--- a/packages/global/scss/components/_podcasts-page.scss
+++ b/packages/global/scss/components/_podcasts-page.scss
@@ -36,3 +36,24 @@
     width: 148px;
   }
 }
+
+.podcast-logo-description-wrapper{
+  display: flex;
+  flex-direction: row;
+  padding-bottom: map-get($spacers, block);
+  .section__logo {
+    margin-right: map-get($spacers, block);
+  }
+}
+
+.podcast-feed {
+  .section-feed-content-node {
+    $self: &;
+
+    &__body {
+      @include media-breakpoint-up(md) {
+        max-width: 100%;
+      }
+    }
+  }
+}

--- a/packages/global/scss/variables/_typography.scss
+++ b/packages/global/scss/variables/_typography.scss
@@ -239,7 +239,7 @@ $typography: non-destructive-map-merge(
       "font-weight": $font-weight-bold,
       "font-size": 24px,
       "font-size-mobile": 18px,
-      "line-height": 1.2,
+      "line-height": 1.35,
       "line-height-mobile": 1.33,
       "letter-spacing": .5px,
       "text-transform": none,

--- a/sites/diverseeducation.com/server/routes/website-section.js
+++ b/sites/diverseeducation.com/server/routes/website-section.js
@@ -1,5 +1,6 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@cox-matthews-associates/package-global/graphql/fragments/website-section-page');
+const queryFragmentWithLogo = require('@cox-matthews-associates/package-global/graphql/fragments/website-section-with-logo-page');
 const cards = require('../templates/website-section/cards');
 const podcasts = require('../templates/website-section/podcasts');
 const products = require('../templates/website-section/products');
@@ -14,7 +15,7 @@ module.exports = (app) => {
   }));
   app.get('/:alias(podcasts)', withWebsiteSection({
     template: podcasts,
-    queryFragment,
+    queryFragment: queryFragmentWithLogo,
   }));
   app.get('/:alias(products)', withWebsiteSection({
     template: products,

--- a/sites/diverseeducation.com/server/templates/website-section/podcasts.marko
+++ b/sites/diverseeducation.com/server/templates/website-section/podcasts.marko
@@ -1,6 +1,6 @@
 $ const { id, alias, name, pageNode } = input;
 
-<global-website-section-feed-layout
+<global-website-section-podcast-feed-layout
   id=id
   alias=alias
   name=name
@@ -23,4 +23,4 @@ $ const { id, alias, name, pageNode } = input;
       <p>We will tackle these topics, and more, head-on. Listen weekly for a mix of deep dives, short briefs, expert panels, interviews, and more. Our award-winning news staff covers higher ed inclusion and equity issues daily on DiverseEducation.com. We are thrilled to bring it to you here, in In The Margins.</p>
     </marko-web-element>
   </@after-name> -->
-</global-website-section-feed-layout>
+</global-website-section-podcast-feed-layout>


### PR DESCRIPTION
This is part of a two phase update to the page.  For now it will be a full width title, logo & description with a feed of 10 podcast per page.  There will be a submit a Podcast form in the right 1/3 once setup.

![podcasts](https://user-images.githubusercontent.com/3845869/143036822-ef0e55e4-96b4-42e0-baf5-8a581949f3a2.jpeg)

