### PR TITLE
Allow for HTML in breadcrumbs.

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,7 +18,7 @@
     "@parameter1/base-cms-marko-web-icons": "^2.46.3",
     "@parameter1/base-cms-marko-web-leaders": "^2.46.3",
     "@parameter1/base-cms-marko-web-p1-events": "^2.52.0",
-    "@parameter1/base-cms-marko-web-theme-default": "^2.51.0",
+    "@parameter1/base-cms-marko-web-theme-default": "^2.62.1",
     "@parameter1/base-cms-object-path": "^2.45.0",
     "@parameter1/base-cms-utils": "^2.22.2",
     "@parameter1/base-cms-web-cli": "^2.62.0",

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -29,7 +29,7 @@
     "@parameter1/base-cms-marko-web-p1-events": "^2.52.0",
     "@parameter1/base-cms-marko-web-search": "^2.62.0",
     "@parameter1/base-cms-marko-web-social-sharing": "^2.22.2",
-    "@parameter1/base-cms-marko-web-theme-default": "^2.51.0",
+    "@parameter1/base-cms-marko-web-theme-default": "^2.62.1",
     "@parameter1/base-cms-object-path": "^2.45.0",
     "@parameter1/base-cms-utils": "^2.22.2",
     "@parameter1/base-cms-web-cli": "^2.62.0",

--- a/packages/theme-monorail/components/breadcrumbs/website-section.marko
+++ b/packages/theme-monorail/components/breadcrumbs/website-section.marko
@@ -18,12 +18,12 @@ $ const displayHome = defaultValue(input.displayHome, true);
     <if(section.alias !== homeAlias)>
       <if(displaySelf)>
         <@item>
-          <marko-web-link title=child.name href=`/${child.alias}`>${child.name}</marko-web-link>
+          <marko-web-link title=child.name href=`/${child.alias}`>$!{child.name}</marko-web-link>
         </@item>
       </if>
       <else-if(child.alias !== section.alias)>
         <@item>
-          <marko-web-link title=child.name href=`/${child.alias}`>${child.name}</marko-web-link>
+          <marko-web-link title=child.name href=`/${child.alias}`>$!{child.name}</marko-web-link>
         </@item>
       </else-if>
     </if>

--- a/sites/ccnewsnow.com/package.json
+++ b/sites/ccnewsnow.com/package.json
@@ -27,7 +27,7 @@
     "@parameter1/base-cms-marko-web-native-x": "^2.48.1",
     "@parameter1/base-cms-marko-web-p1-events": "^2.52.0",
     "@parameter1/base-cms-marko-web-reveal-ad": "^2.45.0",
-    "@parameter1/base-cms-marko-web-theme-default": "^2.51.0",
+    "@parameter1/base-cms-marko-web-theme-default": "^2.62.1",
     "@parameter1/base-cms-object-path": "^2.45.0",
     "@parameter1/base-cms-utils": "^2.22.2",
     "@parameter1/base-cms-web-cli": "^2.62.0",

--- a/sites/diverseeducation.com/package.json
+++ b/sites/diverseeducation.com/package.json
@@ -27,7 +27,7 @@
     "@parameter1/base-cms-marko-web-native-x": "^2.48.1",
     "@parameter1/base-cms-marko-web-p1-events": "^2.52.0",
     "@parameter1/base-cms-marko-web-reveal-ad": "^2.45.0",
-    "@parameter1/base-cms-marko-web-theme-default": "^2.51.0",
+    "@parameter1/base-cms-marko-web-theme-default": "^2.62.1",
     "@parameter1/base-cms-object-path": "^2.45.0",
     "@parameter1/base-cms-utils": "^2.22.2",
     "@parameter1/base-cms-web-cli": "^2.62.0",

--- a/sites/diversemilitary.net/package.json
+++ b/sites/diversemilitary.net/package.json
@@ -27,7 +27,7 @@
     "@parameter1/base-cms-marko-web-native-x": "^2.48.1",
     "@parameter1/base-cms-marko-web-p1-events": "^2.52.0",
     "@parameter1/base-cms-marko-web-reveal-ad": "^2.45.0",
-    "@parameter1/base-cms-marko-web-theme-default": "^2.51.0",
+    "@parameter1/base-cms-marko-web-theme-default": "^2.62.1",
     "@parameter1/base-cms-object-path": "^2.45.0",
     "@parameter1/base-cms-utils": "^2.22.2",
     "@parameter1/base-cms-web-cli": "^2.62.0",

--- a/sites/divhealth.net/package.json
+++ b/sites/divhealth.net/package.json
@@ -27,7 +27,7 @@
     "@parameter1/base-cms-marko-web-native-x": "^2.48.1",
     "@parameter1/base-cms-marko-web-p1-events": "^2.52.0",
     "@parameter1/base-cms-marko-web-reveal-ad": "^2.45.0",
-    "@parameter1/base-cms-marko-web-theme-default": "^2.51.0",
+    "@parameter1/base-cms-marko-web-theme-default": "^2.62.1",
     "@parameter1/base-cms-object-path": "^2.45.0",
     "@parameter1/base-cms-utils": "^2.22.2",
     "@parameter1/base-cms-web-cli": "^2.62.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2413,10 +2413,10 @@
   dependencies:
     "@parameter1/base-cms-utils" "^2.22.2"
 
-"@parameter1/base-cms-marko-web-theme-default@^2.51.0":
-  version "2.51.0"
-  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-theme-default/-/base-cms-marko-web-theme-default-2.51.0.tgz#d31604a331ece610eb9bbcb1c6c5e9ed427b2185"
-  integrity sha512-WtHdwv+C4VnGjffXTbWQXFkdrV/CwzS0WkDFwOFo+WVuQMbolNjl7AYdD+F4C3tjqbhzRgqTBLX4rHeeKaVDVw==
+"@parameter1/base-cms-marko-web-theme-default@^2.62.1":
+  version "2.62.1"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-theme-default/-/base-cms-marko-web-theme-default-2.62.1.tgz#f0260e30166ed51e273b779e13e209e9abe3a133"
+  integrity sha512-N7AQsAA6Jm1Ru0AHvtm1Mf5EOe9EIPviYhqGfZxyfomI+soEFda+4wWi6ySpNFLcw6E2i+wvA/MQxCWXGZBNcg==
   dependencies:
     "@parameter1/base-cms-marko-web-icons" "^2.46.3"
     "@parameter1/base-cms-object-path" "^2.45.0"


### PR DESCRIPTION
Updated to permit the change made here: https://github.com/parameter1/base-cms/pull/209

EDIT: This also needed to be done in the theme-monorail package.