### PR TITLE
Adjust image CSS for mobile view on podcast page

### DIFF
--- a/packages/global/scss/components/_podcasts-page.scss
+++ b/packages/global/scss/components/_podcasts-page.scss
@@ -38,8 +38,10 @@
 }
 
 .podcast-logo-description-wrapper{
-  display: flex;
-  flex-direction: row;
+  @include media-breakpoint-up(md) {
+    display: flex;
+    flex-direction: row;
+  }
   padding-bottom: map-get($spacers, block);
   .section__logo {
     margin-right: map-get($spacers, block);


### PR DESCRIPTION
<img width="583" alt="Screen Shot 2022-01-04 at 10 08 05 AM" src="https://user-images.githubusercontent.com/64623209/148088370-57e9efe9-ad4b-4632-8dc8-4504a00e1afc.png">
