### PR TITLE
Add ‘Submit your professional appointment’ button to content-body

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -141,13 +141,15 @@ $ const excludeFromSidebarsLabel = ["Scholar Profile"];
 
         $ const bodyModifiers = new Set([83113]).has(primarySection.id) ? ['on-the-move'] : []
         <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } modifiers=bodyModifiers />
-        <marko-web-block>
-          <div class="social-sharing" align="center">
-            <a class="btn btn-primary" target="_blank" href="https://responses.diverseeducation.com/OnTheMove2021">
-              Submit Your Professional Appointment
-            </a>
-          </div>
-        </marko-web-block>
+        <if(bodyModifiers)>
+          <marko-web-block>
+            <div class="social-sharing" align="center">
+              <a class="btn btn-primary" target="_blank" href="https://responses.diverseeducation.com/OnTheMove2021">
+                Submit Your Professional Appointment
+              </a>
+            </div>
+          </marko-web-block>
+        </if>
 
         <!-- needs input -->
         <if(input.afterBody)>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -141,7 +141,7 @@ $ const isOnTheMoveSection = new Set([83113]).has(primarySection.id);
           </marko-web-block>
         </for>
 
-        $ const bodyModifiers =  isOnTheMoveSection ? ['on-the-move'] : []
+        $ const bodyModifiers = isOnTheMoveSection ? ['on-the-move'] : []
         <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } modifiers=bodyModifiers />
         <if(isOnTheMoveSection)>
           <marko-web-block>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -14,7 +14,6 @@ $ const displayComments = ["contact"].includes(type) ? false : true;
 $ const displayNewsletterSignup = ["contact"].includes(type) ? false : true;
 $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type);
 $ const excludeFromSidebarsLabel = ["Scholar Profile"];
-
 $ const isOnTheMoveSection = new Set([83113]).has(primarySection.id);
 
 <global-content-wrapper-layout

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -2,7 +2,7 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { site } = out.global;
-$ const { id, type, pageNode, showReadNextBlock, showBottomAdBlock, showTopStoryBlock, ...rest } = input;
+$ const { id, type, primarySection, pageNode, showReadNextBlock, showBottomAdBlock, showTopStoryBlock, ...rest } = input;
 $ const sections = getAsArray(input, "sections");
 $ const belowContentSections = getAsArray(input, "belowContentSections");
 
@@ -14,6 +14,8 @@ $ const displayComments = ["contact"].includes(type) ? false : true;
 $ const displayNewsletterSignup = ["contact"].includes(type) ? false : true;
 $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type);
 $ const excludeFromSidebarsLabel = ["Scholar Profile"];
+
+$ const isOnTheMoveSection = new Set([83113]).has(primarySection.id);
 
 <global-content-wrapper-layout
   id=id
@@ -139,9 +141,9 @@ $ const excludeFromSidebarsLabel = ["Scholar Profile"];
           </marko-web-block>
         </for>
 
-        $ const bodyModifiers = new Set([83113]).has(primarySection.id) ? ['on-the-move'] : []
+        $ const bodyModifiers =  isOnTheMoveSection ? ['on-the-move'] : []
         <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } modifiers=bodyModifiers />
-        <if(bodyModifiers)>
+        <if(isOnTheMoveSection)>
           <marko-web-block>
             <div class="social-sharing" align="center">
               <a class="btn btn-primary" target="_blank" href="https://responses.diverseeducation.com/OnTheMove2021">

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -141,6 +141,13 @@ $ const excludeFromSidebarsLabel = ["Scholar Profile"];
 
         $ const bodyModifiers = new Set([83113]).has(primarySection.id) ? ['on-the-move'] : []
         <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } modifiers=bodyModifiers />
+        <marko-web-block>
+          <div class="social-sharing" align="center">
+            <a class="btn btn-primary" target="_blank" href="https://responses.diverseeducation.com/OnTheMove2021">
+              Submit Your Professional Appointment
+            </a>
+          </div>
+        </marko-web-block>
 
         <!-- needs input -->
         <if(input.afterBody)>


### PR DESCRIPTION
block for ‘On the Move’ section

<img width="868" alt="Screen Shot 2022-01-24 at 11 49 20 AM" src="https://user-images.githubusercontent.com/64623209/150837149-4b908829-bdd4-4b61-852f-1aa773f9a5c9.png">
