### PR TITLE
Require image for premium-employers block.

### DIFF
--- a/packages/global/components/blocks/premium-employers.marko
+++ b/packages/global/components/blocks/premium-employers.marko
@@ -10,6 +10,7 @@ $ const queryParams = {
   siteId: "60c281c6d28860bc33464ae0",
   ...input.queryParams,
   includeContentTypes: ["Company", "Promotion"],
+  requiresImage: true,
   limit: 12,
   sectionAlias: alias,
   queryFragment,


### PR DESCRIPTION
Some of these were returning without a primaryImage and displaying an "empty slot"

<img width="1920" alt="Screen Shot 2022-03-31 at 11 31 25 AM" src="https://user-images.githubusercontent.com/46794001/161105188-e34aed12-15c4-428d-bb91-8bfb2d38f585.png">
<img width="1464" alt="Screen Shot 2022-03-31 at 11 28 03 AM" src="https://user-images.githubusercontent.com/46794001/161105175-519627d7-d7f1-4c97-9c7a-f3bde7f37111.png">
<img width="1141" alt="Screen Shot 2022-03-31 at 11 28 28 AM" src="https://user-images.githubusercontent.com/46794001/161105180-6d518fae-227f-40f6-9b87-0152b0be5d9e.png">
