### PR TITLE
Update ‘Diverse Champions’ page with 2022 winner

### DIFF
--- a/sites/diverseeducation.com/server/templates/website-section/awards-honors/champions.marko
+++ b/sites/diverseeducation.com/server/templates/website-section/awards-honors/champions.marko
@@ -101,6 +101,7 @@ $ const params = {
             <marko-web-img
               alt="Dr. Eboni Zamani-Gallaher"
               src="https://img.diverseeducation.com/files/base/diverse/all/image/static/de/champions/Dr._Eboni_Zamani-Gallaher.jpg?auto=format%2Ccompress&amp;h=167&amp;q=70&amp;w=250"
+              srcset="https://img.diverseeducation.com/files/base/diverse/all/image/static/de/champions/Dr._Eboni_Zamani-Gallaher.jpg?auto=format%2Ccompress&amp;h=167&amp;q=70&amp;w=250 2x"
             />
           </div>
         </div>


### PR DESCRIPTION
<img width="1243" alt="Screen Shot 2022-05-04 at 8 03 50 AM" src="https://user-images.githubusercontent.com/64623209/166686836-dc723267-4570-4e83-8bc4-6bd1783e90f3.png">
