### PR TITLE
Adjust ‘Keep it Real’ link to http…

### DIFF
--- a/sites/diverseeducation.com/config/navigation.js
+++ b/sites/diverseeducation.com/config/navigation.js
@@ -24,7 +24,7 @@ const resources = [
   { href: 'https://www.divhealth.net', label: 'Health', target: '_blank' },
   { href: 'https://diversejobs.net', label: 'Jobs', target: '_blank' },
   { href: 'https://www.diversemilitary.net', label: 'Military', target: '_blank' },
-  { href: 'https://keepitreal.diverseeducation.com/', label: 'Keep it Real', target: '_blank' },
+  { href: 'http://keepitreal.diverseeducation.com/', label: 'Keep it Real', target: '_blank' },
 ];
 
 const awards = [


### PR DESCRIPTION
due to SSL certificate error (Diverse is aware of issue)