### PR TITLE
Add premium employers slider

### DIFF
--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -2,8 +2,11 @@ import GCSE from '@parameter1/base-cms-marko-web-gcse/browser';
 import ContactUs from '@parameter1/base-cms-marko-web-contact-us/browser';
 import MonoRail from '@parameter1/base-cms-marko-web-theme-monorail/browser';
 
+const GlobalPremiumEmployers = () => import(/* webpackChunkName: "global-premium-employers" */ './premium-employers.vue');
+
 export default (Browser) => {
   GCSE(Browser);
   ContactUs(Browser);
   MonoRail(Browser);
+  Browser.register('GlobalPremiumEmployers', GlobalPremiumEmployers);
 };

--- a/packages/global/browser/premium-employers.vue
+++ b/packages/global/browser/premium-employers.vue
@@ -43,7 +43,7 @@ export default {
   data: () => ({
     SlickCarouselSettings: {
       autoplay: true,
-      autoplaySpeed: 10000,
+      autoplaySpeed: 5000,
       speed: 1000,
       variableWidth: false,
       dots: false,

--- a/packages/global/browser/premium-employers.vue
+++ b/packages/global/browser/premium-employers.vue
@@ -3,7 +3,6 @@
     <div>
       <vue-slick-carousel
         v-bind="SlickCarouselSettings"
-        :class="(SlickCarouselSettings.arrows)?'with-arrows':'without-arrows'"
       >
         <a
           v-for="(employer) in employers"
@@ -65,15 +64,6 @@ export default {
       ],
     },
   }),
-
-  mounted() {
-    const employersCount = this.employers.length;
-    const employersPerScroll = this.SlickCarouselSettings.slidesToShow;
-    if (employersCount <= employersPerScroll) {
-      this.SlickCarouselSettings.autoplay = false;
-      this.SlickCarouselSettings.arrows = false;
-    }
-  },
 
   methods: {
     getImgSrc(imagePath) {

--- a/packages/global/browser/premium-employers.vue
+++ b/packages/global/browser/premium-employers.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="premium-employers">
     <div>
-      <vue-slick-carousel v-bind="SlickCarouselSettings">
+      <vue-slick-carousel
+        v-bind="SlickCarouselSettings"
+        :class="(SlickCarouselSettings.arrows)?'with-arrows':'without-arrows'"
+      >
         <a
           v-for="(employer) in employers"
           :key="employer.shortName"
@@ -41,11 +44,12 @@ export default {
   data: () => ({
     SlickCarouselSettings: {
       autoplay: true,
+      autoplaySpeed: 5000,
+      variableWidth: false,
       dots: false,
       arrows: true,
       focusOnSelect: false,
       infinite: true,
-      speed: 2500,
       slidesToShow: 4,
       slidesToScroll: 4,
       touchThreshold: 5,
@@ -61,20 +65,21 @@ export default {
     },
   }),
 
+  mounted() {
+    const employersCount = this.employers.length;
+    const employersPerScroll = this.SlickCarouselSettings.slidesToShow;
+    if (employersCount <= employersPerScroll) {
+      this.SlickCarouselSettings.autoplay = false;
+      this.SlickCarouselSettings.arrows = false;
+    }
+  },
+
   methods: {
     getImgSrc(imagePath) {
       return `${imagePath}?auto=format%2Ccompress&bg=fff&dpr=2&fill-color=fff&fit=fill&h=141&pad=5&q=70&w=240`;
     },
     getImgSrcSet(imagePath) {
       return `${imagePath}?auto=format%2Ccompress&bg=fff&dpr=2&fill-color=fff&fit=fill&h=141&pad=5&q=70&w=240&dpr=2 2x`;
-    },
-    shuffleArray(a) {
-      const shuffled = [...a];
-      for (let i = shuffled.length - 1; i > 0; i -= 1) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-      }
-      return shuffled;
     },
   },
 };

--- a/packages/global/browser/premium-employers.vue
+++ b/packages/global/browser/premium-employers.vue
@@ -44,7 +44,8 @@ export default {
   data: () => ({
     SlickCarouselSettings: {
       autoplay: true,
-      autoplaySpeed: 5000,
+      autoplaySpeed: 10000,
+      speed: 1000,
       variableWidth: false,
       dots: false,
       arrows: true,

--- a/packages/global/browser/premium-employers.vue
+++ b/packages/global/browser/premium-employers.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="premium-employers">
+    <div>
+      <vue-slick-carousel v-bind="SlickCarouselSettings">
+        <a
+          v-for="(employer) in employers"
+          :key="employer.shortName"
+          :href="employer.siteContext.path"
+          :title="employer.shortName"
+          class="premium-employers__link"
+          target="_blank"
+          rel="nofollow"
+        >
+          <img
+            class="premium-employers__logo lazyload"
+            src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+            srcset=""
+            :data-src="getImgSrc(employer.primaryImage.src)"
+            :data-srcset="[getImgSrcSet(employer.primaryImage.src)]"
+            :alt="employer.shortName"
+          >
+        </a>
+      </vue-slick-carousel>
+    </div>
+  </div>
+</template>
+
+<script>
+import VueSlickCarousel from 'vue-slick-carousel';
+
+export default {
+  components: { VueSlickCarousel },
+
+  props: {
+    employers: {
+      type: Array,
+      required: true,
+    },
+  },
+
+  data: () => ({
+    SlickCarouselSettings: {
+      autoplay: true,
+      dots: false,
+      arrows: true,
+      focusOnSelect: false,
+      infinite: true,
+      speed: 2500,
+      slidesToShow: 4,
+      slidesToScroll: 4,
+      touchThreshold: 5,
+      responsive: [
+        {
+          breakpoint: 600,
+          settings: {
+            slidesToShow: 2,
+            slidesToScroll: 2,
+          },
+        },
+      ],
+    },
+  }),
+
+  methods: {
+    getImgSrc(imagePath) {
+      return `${imagePath}?auto=format%2Ccompress&bg=fff&dpr=2&fill-color=fff&fit=fill&h=141&pad=5&q=70&w=240`;
+    },
+    getImgSrcSet(imagePath) {
+      return `${imagePath}?auto=format%2Ccompress&bg=fff&dpr=2&fill-color=fff&fit=fill&h=141&pad=5&q=70&w=240&dpr=2 2x`;
+    },
+    shuffleArray(a) {
+      const shuffled = [...a];
+      for (let i = shuffled.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+      }
+      return shuffled;
+    },
+  },
+};
+</script>

--- a/packages/global/browser/ssr.js
+++ b/packages/global/browser/ssr.js
@@ -1,5 +1,7 @@
 import ThemeComponents from '@parameter1/base-cms-marko-web-theme-monorail/browser/ssr';
+import GlobalPremiumEmployers from './premium-employers.vue';
 
 export default {
   ...ThemeComponents,
+  GlobalPremiumEmployers,
 };

--- a/packages/global/components/blocks/premium-employers.marko
+++ b/packages/global/components/blocks/premium-employers.marko
@@ -4,7 +4,6 @@ import shuffle from "../../utils/shuffle-array";
 
 $ const { GAM } = out.global;
 $ const alias = defaultValue(input.alias, 'premium-employers');
-$ const displayLimit = 4;
 
 $ const queryParams = {
   ...input.queryParams,
@@ -20,28 +19,18 @@ $ const blockName = "premium-employers";
 
 <marko-web-query|{ nodes: allNodes }| name="website-scheduled-content" params=queryParams>
   <marko-web-block name=blockName>
-    $ const nodes = shuffle(allNodes).slice(0, displayLimit);
+    $ const nodes = shuffle(allNodes);
     <if(title)>
       <marko-web-element block-name=blockName name="header">
         ${title}
       </marko-web-element>
     </if>
-    <default-theme-card-deck-flow cols=displayLimit nodes=nodes modifiers=[blockName]>
-      <@slot|{ node }|>
-        <theme-content-node
-          image-position="top"
-          card=true
-          flush=true
-          full-height=true
-          with-teaser=false
-          with-dates=false
-          with-section=false
-          modifiers=[blockName]
-          node=node
-        >
-          <@image ar="16:9" fluid=true />
-        </theme-content-node>
-      </@slot>
-    </default-theme-card-deck-flow>
+    <marko-web-browser-component
+      name="GlobalPremiumEmployers"
+      props={
+        employers: nodes,
+      }
+      ssr=true
+    />
   </marko-web-block>
 </marko-web-query>

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -45,6 +45,7 @@
     "newrelic": "^6.4.1",
     "node-fetch": "^2.6.1",
     "object-path": "^0.11.5",
-    "slug": "^4.0.2"
+    "slug": "^4.0.2",
+    "vue-slick-carousel": "^1.0.6"
   }
 }

--- a/packages/global/scss/components/blocks/_premium-employers.scss
+++ b/packages/global/scss/components/blocks/_premium-employers.scss
@@ -1,3 +1,5 @@
+@charset 'UTF-8';
+
 .premium-employers {
   &__header {
     padding-bottom: 10px;
@@ -28,4 +30,305 @@
       }
     }
   }
+}
+
+// Vue Slick Carousel CSS inclusion
+
+/* Icons */
+@font-face {
+  font-family: 'slick';
+  src: url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAATsAA0AAAAAB2wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAAE0AAAABoAAAAcdIcYB0dERUYAAAS0AAAAHAAAAB4AJwANT1MvMgAAAZwAAABRAAAAYFAQ/45jbWFwAAACAAAAAFcAAAFiIhFFt2dhc3AAAASsAAAACAAAAAj//wADZ2x5ZgAAAmgAAAE1AAACLD+btmBoZWFkAAABMAAAAC8AAAA2AAEx+2hoZWEAAAFgAAAAHAAAACQD5QIFaG10eAAAAfAAAAAQAAAAFgZKAEpsb2NhAAACWAAAABAAAAAQATYBoG1heHAAAAF8AAAAHQAAACAASwBHbmFtZQAAA6AAAADcAAABbgUngcJwb3N0AAAEfAAAAC4AAABFOXjBpHjaY2BkYGAA4vMGfuHx/DZfGbiZGEDgfGFFPZxWZVBlvM14G8jlYABLAwAT1QnNAHjaY2BkYGC8zcDAoMfEAAJANiMDKmABADBkAe942mNgZGBgYGdwYWBiAAEQycgAEnMA8xkACcgAkwAAAHjaY2BmYmCcwMDKwMDow5jGwMDgDqW/MkgytDAwMDGwcjKAQQNQCZBSYICCgDTXFAYHhkTFSYwP/j9g0GO8/f82A0QNA+NtsBIFBkYANHMN4wAAAHjaY2KAACYIVoVAAALCAJt42mNgYGBmgGAZBkYGEIgB8hjBfBYGByDNw8DBwARkMzAkKigpTlCc9P8/WB0S7/+i+4/uld4rgZoAB4xsDHAhRiYgwcSApoCBcsBMBTNYGGgGAEdEDyUAAAAAAAAAAAAAZgCKANABFnjadZBdToNAEMd3CrtAl5TQLtS0LCoN0A8SGkBI+mAfPET75B1896HppfQcvnII4w3cLYpW6k4ymdn9z8xvBwEKUQg11OgBIXAYWUEQR1uIZoFGpLGxKy3PqrIq8+waXIfJ+5mQSSvkvXwRqqocu1D39QMl2JgvN9zzhsyk1GRDz+OBfzMioCqx0rtdLYo0SiZTZttsOkmidBkveKibFF4Oep9SI46bqk3Twhp4iihUemrMWFPy2NRbthfqKkHi/PxlJLITZdAiSj6ouZ+tn9eZz78DuD9LZYB6bZ8rlCAUVuVdkULjxV4sIEysIc/KSyPmnJDdjhCOdQ0fCTliTX/tjH3ysWao+71qaNjHQjcQwrcuyl+WLZQthCMotJP/h+Xjazz+hfTeRWmG4zOiSyif/q1OtAAAAHjabY49asNAEIU/2ZJDfkiRIvXapUFCEqpcptABUrg3ZhEiQoKVfY9UqVLlGDlADpAT5e16IUWysMz3hjfzBrjjjQT/EjKpCy+4YhN5yZoxcirPe+SMWz4jr6S+5UzSa3VuwpTnBfc8RF7yxDZyKs9r5IxHPiKv1P9iZqDnyAvMQ39UecbScVb/gJO03Xk4CFom3XYK1clhMdQUlKo7/d9NF13RkIdfy+MV7TSe2sl11tRFaXYmJKpWTd7kdVnJ8veevZKc+n3I93t9Jnvr5n4aTVWU/0z9AI2qMkV42mNgYkAGjAzogB0sysTgwtDOyMTIzJlYVJRfnpOaVsIFZhVlpmeUAABuKQkSAAAAAAAB//8AAnjaY2BkYGDgAWIxIGZiYARCNiBmAfMYAAPgADV42mNgYGBkAIKrS9Q5QPT5wop6GA0APf8GGAAA)
+    format('woff');
+}
+/* Arrows */
+.slick-prev,
+.slick-next {
+  font-size: 0;
+  line-height: 0;
+
+  position: absolute;
+  top: 50%;
+
+  display: block;
+
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  -webkit-transform: translate(0, -50%);
+  -ms-transform: translate(0, -50%);
+  transform: translate(0, -50%);
+
+  cursor: pointer;
+
+  color: transparent;
+  border: none;
+  outline: none;
+  background: transparent;
+}
+.slick-prev:hover,
+.slick-prev:focus,
+.slick-next:hover,
+.slick-next:focus {
+  color: transparent;
+  outline: none;
+  background: transparent;
+}
+.slick-prev:hover:before,
+.slick-prev:focus:before,
+.slick-next:hover:before,
+.slick-next:focus:before {
+  opacity: 1;
+}
+.slick-prev.slick-disabled:before,
+.slick-next.slick-disabled:before {
+  opacity: 0.25;
+}
+
+.slick-prev:before,
+.slick-next:before {
+  font-family: 'slick';
+  font-size: 20px;
+  line-height: 1;
+
+  opacity: 0.75;
+  color: white;
+
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.slick-prev {
+  left: -25px;
+}
+[dir='rtl'] .slick-prev {
+  right: -25px;
+  left: auto;
+}
+.slick-prev:before {
+  content: '←';
+}
+[dir='rtl'] .slick-prev:before {
+  content: '→';
+}
+
+.slick-next {
+  right: -25px;
+}
+[dir='rtl'] .slick-next {
+  right: auto;
+  left: -25px;
+}
+.slick-next:before {
+  content: '→';
+}
+[dir='rtl'] .slick-next:before {
+  content: '←';
+}
+
+/* Dots */
+.slick-dotted.slick-slider {
+  margin-bottom: 30px;
+}
+
+.slick-dots {
+  position: absolute;
+  bottom: -25px;
+
+  display: block;
+
+  width: 100%;
+  padding: 0;
+  margin: 0;
+
+  list-style: none;
+
+  text-align: center;
+}
+.slick-dots li {
+  position: relative;
+
+  display: inline-block;
+
+  width: 20px;
+  height: 20px;
+  margin: 0 5px;
+  padding: 0;
+
+  cursor: pointer;
+}
+.slick-dots li button {
+  font-size: 0;
+  line-height: 0;
+
+  display: block;
+
+  width: 20px;
+  height: 20px;
+  padding: 5px;
+
+  cursor: pointer;
+
+  color: transparent;
+  border: 0;
+  outline: none;
+  background: transparent;
+}
+.slick-dots li button:hover,
+.slick-dots li button:focus {
+  outline: none;
+}
+.slick-dots li button:hover:before,
+.slick-dots li button:focus:before {
+  opacity: 1;
+}
+.slick-dots li button:before {
+  font-family: 'slick';
+  font-size: 6px;
+  line-height: 20px;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: 20px;
+  height: 20px;
+
+  content: '•';
+  text-align: center;
+
+  opacity: 0.25;
+  color: black;
+
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.slick-dots li.slick-active button:before {
+  opacity: 0.75;
+  color: black;
+}
+
+
+.slick-track {
+  position:relative;
+  top:0;
+  left:0;
+  display:block;
+  -webkit-transform:translateZ(0);
+  transform:translateZ(0)
+}
+
+.slick-track.slick-center {
+  margin-left:auto;
+  margin-right:auto
+}
+
+.slick-track:after,
+.slick-track:before {
+  display:table;
+  content:""
+}
+
+.slick-track:after {
+  clear:both
+}
+
+.slick-loading .slick-track {
+  visibility:hidden
+}
+
+.slick-slide {
+  display:none;
+  float:left;
+  height:100%;
+  min-height:1px
+}
+
+[dir=rtl] .slick-slide {
+  float:right
+}
+
+.slick-slide img {
+  display:block
+}
+
+.slick-slide.slick-loading img {
+  display:none
+}
+
+.slick-slide.dragging img {
+  pointer-events:none
+}
+
+.slick-initialized .slick-slide {
+  display:block
+}
+
+.slick-loading .slick-slide {
+  visibility:hidden
+}
+
+.slick-vertical .slick-slide {
+  display:block;
+  height:auto;
+  border:1px solid transparent
+}
+
+.slick-arrow.slick-hidden {
+  display:none
+}
+
+.slick-slider {
+  position:relative;
+  display:block;
+  -webkit-box-sizing:border-box;
+  box-sizing:border-box;
+  -webkit-user-select:none;
+  -moz-user-select:none;
+  -ms-user-select:none;
+  user-select:none;
+  -webkit-touch-callout:none;
+  -khtml-user-select:none;
+  -ms-touch-action:pan-y;
+  touch-action:pan-y;
+  -webkit-tap-highlight-color:transparent
+}
+
+.slick-list {
+  position:relative;
+  display:block;
+  overflow:hidden;
+  margin:0;
+  padding:0;
+  -webkit-transform:translateZ(0);
+  transform:translateZ(0)
+}
+
+.slick-list:focus {
+  outline:none
+}
+
+.slick-list.dragging {
+  cursor:pointer;
+  cursor:hand
+}
+
+.premium-employers {
+  &__link {
+    padding: 0 1rem;
+  }
+  &__logo {
+    width: 100%;
+  }
+
+}
+
+.slick-next:before, .slick-prev:before {
+  color: #000;
+}
+.slick-slide {
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+.slick-slider {
+  margin: 0 25px;
 }

--- a/packages/global/scss/components/blocks/_premium-employers.scss
+++ b/packages/global/scss/components/blocks/_premium-employers.scss
@@ -1,337 +1,65 @@
-@charset 'UTF-8';
-
 .premium-employers {
-  &__header {
-    padding-bottom: 10px;
-    margin-bottom: 24px;
-    border-bottom: 1px solid $gray-700;
-    @include media-breakpoint-up(md) {
-      margin-bottom: 30px;
-    }
-    @include skin-typography($style: "section-header");
-  }
-}
+  width: 100%;
 
-.node {
-  $self: &;
-  &--premium-employers {
-    #{ $self }__body {
-      display: none;
+  .slick-list {
+    max-width: 100%;
+    overflow: hidden;
+    &:only-child {
+      width: 100%;
     }
   }
-}
-
-.page-wrapper {
-  &__section {
-    &--break-container {
-      .premium-employers {
-        padding-top: 50px;
-        padding-bottom: 50px;
+  .slick-track {
+    display: flex;
+    width: 100%;
+  }
+  .slick-slider {
+    display: flex;
+    align-items: center;
+    .slick-arrow {
+      width: 40px;
+      height: 30px;
+    }
+  }
+  .slick-slide {
+    margin: 0 10px;
+    &.slick-active:first-of-type {
+      margin-left: 0;
+    }
+    &.slick-active:last-of-type {
+      margin-right: 0;
+    }
+    .premium-employers {
+      &__logo {
+        width: 100%;
+        aspect-ratio: 16 / 9;
       }
     }
   }
-}
-
-// Vue Slick Carousel CSS inclusion
-
-/* Icons */
-@font-face {
-  font-family: 'slick';
-  src: url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAATsAA0AAAAAB2wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAAE0AAAABoAAAAcdIcYB0dERUYAAAS0AAAAHAAAAB4AJwANT1MvMgAAAZwAAABRAAAAYFAQ/45jbWFwAAACAAAAAFcAAAFiIhFFt2dhc3AAAASsAAAACAAAAAj//wADZ2x5ZgAAAmgAAAE1AAACLD+btmBoZWFkAAABMAAAAC8AAAA2AAEx+2hoZWEAAAFgAAAAHAAAACQD5QIFaG10eAAAAfAAAAAQAAAAFgZKAEpsb2NhAAACWAAAABAAAAAQATYBoG1heHAAAAF8AAAAHQAAACAASwBHbmFtZQAAA6AAAADcAAABbgUngcJwb3N0AAAEfAAAAC4AAABFOXjBpHjaY2BkYGAA4vMGfuHx/DZfGbiZGEDgfGFFPZxWZVBlvM14G8jlYABLAwAT1QnNAHjaY2BkYGC8zcDAoMfEAAJANiMDKmABADBkAe942mNgZGBgYGdwYWBiAAEQycgAEnMA8xkACcgAkwAAAHjaY2BmYmCcwMDKwMDow5jGwMDgDqW/MkgytDAwMDGwcjKAQQNQCZBSYICCgDTXFAYHhkTFSYwP/j9g0GO8/f82A0QNA+NtsBIFBkYANHMN4wAAAHjaY2KAACYIVoVAAALCAJt42mNgYGBmgGAZBkYGEIgB8hjBfBYGByDNw8DBwARkMzAkKigpTlCc9P8/WB0S7/+i+4/uld4rgZoAB4xsDHAhRiYgwcSApoCBcsBMBTNYGGgGAEdEDyUAAAAAAAAAAAAAZgCKANABFnjadZBdToNAEMd3CrtAl5TQLtS0LCoN0A8SGkBI+mAfPET75B1896HppfQcvnII4w3cLYpW6k4ymdn9z8xvBwEKUQg11OgBIXAYWUEQR1uIZoFGpLGxKy3PqrIq8+waXIfJ+5mQSSvkvXwRqqocu1D39QMl2JgvN9zzhsyk1GRDz+OBfzMioCqx0rtdLYo0SiZTZttsOkmidBkveKibFF4Oep9SI46bqk3Twhp4iihUemrMWFPy2NRbthfqKkHi/PxlJLITZdAiSj6ouZ+tn9eZz78DuD9LZYB6bZ8rlCAUVuVdkULjxV4sIEysIc/KSyPmnJDdjhCOdQ0fCTliTX/tjH3ysWao+71qaNjHQjcQwrcuyl+WLZQthCMotJP/h+Xjazz+hfTeRWmG4zOiSyif/q1OtAAAAHjabY49asNAEIU/2ZJDfkiRIvXapUFCEqpcptABUrg3ZhEiQoKVfY9UqVLlGDlADpAT5e16IUWysMz3hjfzBrjjjQT/EjKpCy+4YhN5yZoxcirPe+SMWz4jr6S+5UzSa3VuwpTnBfc8RF7yxDZyKs9r5IxHPiKv1P9iZqDnyAvMQ39UecbScVb/gJO03Xk4CFom3XYK1clhMdQUlKo7/d9NF13RkIdfy+MV7TSe2sl11tRFaXYmJKpWTd7kdVnJ8veevZKc+n3I93t9Jnvr5n4aTVWU/0z9AI2qMkV42mNgYkAGjAzogB0sysTgwtDOyMTIzJlYVJRfnpOaVsIFZhVlpmeUAABuKQkSAAAAAAAB//8AAnjaY2BkYGDgAWIxIGZiYARCNiBmAfMYAAPgADV42mNgYGBkAIKrS9Q5QPT5wop6GA0APf8GGAAA)
-    format('woff');
-}
-/* Arrows */
-.slick-prev,
-.slick-next {
-  font-size: 0;
-  line-height: 0;
-
-  position: absolute;
-  top: 50%;
-
-  display: block;
-
-  width: 20px;
-  height: 20px;
-  padding: 0;
-  -webkit-transform: translate(0, -50%);
-  -ms-transform: translate(0, -50%);
-  transform: translate(0, -50%);
-
-  cursor: pointer;
-
-  color: transparent;
-  border: none;
-  outline: none;
-  background: transparent;
-}
-.slick-prev:hover,
-.slick-prev:focus,
-.slick-next:hover,
-.slick-next:focus {
-  color: transparent;
-  outline: none;
-  background: transparent;
-}
-.slick-prev:hover:before,
-.slick-prev:focus:before,
-.slick-next:hover:before,
-.slick-next:focus:before {
-  opacity: 1;
-}
-.slick-prev.slick-disabled:before,
-.slick-next.slick-disabled:before {
-  opacity: 0.25;
-}
-
-.slick-prev:before,
-.slick-next:before {
-  font-family: 'slick';
-  font-size: 20px;
-  line-height: 1;
-
-  opacity: 0.75;
-  color: white;
-
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-.slick-prev {
-  left: -25px;
-}
-[dir='rtl'] .slick-prev {
-  right: -25px;
-  left: auto;
-}
-.slick-prev:before {
-  content: '←';
-}
-[dir='rtl'] .slick-prev:before {
-  content: '→';
-}
-
-.slick-next {
-  right: -25px;
-}
-[dir='rtl'] .slick-next {
-  right: auto;
-  left: -25px;
-}
-.slick-next:before {
-  content: '→';
-}
-[dir='rtl'] .slick-next:before {
-  content: '←';
-}
-
-/* Dots */
-.slick-dotted.slick-slider {
-  margin-bottom: 30px;
-}
-
-.slick-dots {
-  position: absolute;
-  bottom: -25px;
-
-  display: block;
-
-  width: 100%;
-  padding: 0;
-  margin: 0;
-
-  list-style: none;
-
-  text-align: center;
-}
-.slick-dots li {
-  position: relative;
-
-  display: inline-block;
-
-  width: 20px;
-  height: 20px;
-  margin: 0 5px;
-  padding: 0;
-
-  cursor: pointer;
-}
-.slick-dots li button {
-  font-size: 0;
-  line-height: 0;
-
-  display: block;
-
-  width: 20px;
-  height: 20px;
-  padding: 5px;
-
-  cursor: pointer;
-
-  color: transparent;
-  border: 0;
-  outline: none;
-  background: transparent;
-}
-.slick-dots li button:hover,
-.slick-dots li button:focus {
-  outline: none;
-}
-.slick-dots li button:hover:before,
-.slick-dots li button:focus:before {
-  opacity: 1;
-}
-.slick-dots li button:before {
-  font-family: 'slick';
-  font-size: 6px;
-  line-height: 20px;
-
-  position: absolute;
-  top: 0;
-  left: 0;
-
-  width: 20px;
-  height: 20px;
-
-  content: '•';
-  text-align: center;
-
-  opacity: 0.25;
-  color: black;
-
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-.slick-dots li.slick-active button:before {
-  opacity: 0.75;
-  color: black;
-}
-
-
-.slick-track {
-  position:relative;
-  top:0;
-  left:0;
-  display:block;
-  -webkit-transform:translateZ(0);
-  transform:translateZ(0)
-}
-
-.slick-track.slick-center {
-  margin-left:auto;
-  margin-right:auto
-}
-
-.slick-track:after,
-.slick-track:before {
-  display:table;
-  content:""
-}
-
-.slick-track:after {
-  clear:both
-}
-
-.slick-loading .slick-track {
-  visibility:hidden
-}
-
-.slick-slide {
-  display:none;
-  float:left;
-  height:100%;
-  min-height:1px
-}
-
-[dir=rtl] .slick-slide {
-  float:right
-}
-
-.slick-slide img {
-  display:block
-}
-
-.slick-slide.slick-loading img {
-  display:none
-}
-
-.slick-slide.dragging img {
-  pointer-events:none
-}
-
-.slick-initialized .slick-slide {
-  display:block
-}
-
-.slick-loading .slick-slide {
-  visibility:hidden
-}
-
-.slick-vertical .slick-slide {
-  display:block;
-  height:auto;
-  border:1px solid transparent
-}
-
-.slick-arrow.slick-hidden {
-  display:none
-}
-
-.slick-slider {
-  position:relative;
-  display:block;
-  -webkit-box-sizing:border-box;
-  box-sizing:border-box;
-  -webkit-user-select:none;
-  -moz-user-select:none;
-  -ms-user-select:none;
-  user-select:none;
-  -webkit-touch-callout:none;
-  -khtml-user-select:none;
-  -ms-touch-action:pan-y;
-  touch-action:pan-y;
-  -webkit-tap-highlight-color:transparent
-}
-
-.slick-list {
-  position:relative;
-  display:block;
-  overflow:hidden;
-  margin:0;
-  padding:0;
-  -webkit-transform:translateZ(0);
-  transform:translateZ(0)
-}
-
-.slick-list:focus {
-  outline:none
-}
-
-.slick-list.dragging {
-  cursor:pointer;
-  cursor:hand
-}
-
-.premium-employers {
-  &__link {
-    padding: 0 10px;
+  .slick-arrow {
+    visibility: hidden;
   }
-  &__logo {
-    width: 100%;
+  .slick-prev:before,
+  .slick-next:before {
+    visibility: visible;
+    display: block;
+    border: solid;
+    width: 30px;
+    height: 30px;
+    text-align: center;
+    border-radius: 20px;
+    font-weight: $font-weight-bold;
+    @include media-breakpoint-down(md) {
+      border-radius: 14px;
+      height: 28px;
+      width: 28px;
+      font-size: 14px;
+      line-height: 24px;
+    }
   }
-
-}
-
-.slick-next:before, .slick-prev:before {
-  color: #000;
-}
-.slick-slide {
-  aspect-ratio: 16 / 9;
-  overflow: hidden;
-}
-.slick-slider {
-  margin: 0 25px;
-  &.without-arrows {
-    margin: 0 -10px;
+  .slick-prev:before {
+    content: '<';
+  }
+  .slick-next:before {
+    content: '>';
   }
 }

--- a/packages/global/scss/components/blocks/_premium-employers.scss
+++ b/packages/global/scss/components/blocks/_premium-employers.scss
@@ -314,7 +314,7 @@
 
 .premium-employers {
   &__link {
-    padding: 0 1rem;
+    padding: 0 10px;
   }
   &__logo {
     width: 100%;
@@ -331,4 +331,7 @@
 }
 .slick-slider {
   margin: 0 25px;
+  &.without-arrows {
+    margin: 0 -10px;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -470,6 +470,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.2.tgz#3723cd5c8d8773eef96ce57ea1d9b7faaccd12ac"
   integrity sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==
 
+"@babel/parser@^7.18.4":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.6.tgz#845338edecad65ebffef058d3be851f1d28a63bc"
+  integrity sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw==
+
 "@babel/parser@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
@@ -2886,6 +2891,15 @@
   resolved "https://registry.yarnpkg.com/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz#df3dcbdb1b9182168601f6318366157ee16666e9"
   integrity sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA==
 
+"@vue/compiler-sfc@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.3.tgz#6179ed9787e10c270563e0c1b440955bf9dd8342"
+  integrity sha512-/9SO6KeR1ljo+j4Tdkl9zsFG2yY4NQ9p3GKdPVCU99bmkNkTW8g9Tq8SMEvhOfo+RhBC0PdDAOmibl+N37f5YA==
+  dependencies:
+    "@babel/parser" "^7.18.4"
+    postcss "^8.4.14"
+    source-map "^0.6.1"
+
 "@vue/component-compiler-utils@^3.1.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-3.1.1.tgz#d4ef8f80292674044ad6211e336a302e4d2a6575"
@@ -5200,6 +5214,11 @@ csso@^4.2.0:
   dependencies:
     css-tree "^1.1.2"
 
+csstype@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
+  integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -5791,6 +5810,11 @@ enhanced-resolve@^5.8.3:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+enquire.js@2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/enquire.js/-/enquire.js-2.1.6.tgz#3e8780c9b8b835084c3f60e166dbc3c2a3c89814"
+  integrity sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==
 
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
@@ -8464,6 +8488,13 @@ json-stringify-safe@^5.0.0, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json2mq@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  integrity sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==
+  dependencies:
+    string-convert "^0.2.0"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -8827,6 +8858,11 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -9500,6 +9536,11 @@ nanoid@^3.1.30:
   version "3.1.30"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
   integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -10910,6 +10951,15 @@ postcss@^8.2.15, postcss@^8.3.9:
     picocolors "^1.0.0"
     source-map-js "^0.6.2"
 
+postcss@^8.4.14:
+  version "8.4.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
+  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -11611,6 +11661,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+resize-observer-polyfill@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -12120,6 +12175,11 @@ source-map-js@^0.6.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
@@ -12344,6 +12404,11 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
+  integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
 string-template@~0.2.1:
   version "0.2.1"
@@ -13614,6 +13679,20 @@ vue-server-renderer@^2.6.14:
     serialize-javascript "^3.1.0"
     source-map "0.5.6"
 
+vue-slick-carousel@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/vue-slick-carousel/-/vue-slick-carousel-1.0.6.tgz#8fbfe59a233b0fb7777e4934b60bbdf0a6a24f96"
+  integrity sha512-1CN/hpWC8m1U/eO7Kuc71jntJqdg6Z/ieLji21OPfQUhs8ZYnnGhQSu1covpa3IyuovM9T5puPCVgexs3DDF5A==
+  dependencies:
+    enquire.js "2.1.6"
+    json2mq "0.2.0"
+    lodash.assign "^4.2.0"
+    lodash.debounce "^4.0.8"
+    lodash.get "^4.4.2"
+    lodash.pick "^4.4.0"
+    resize-observer-polyfill "1.5.1"
+    vue "^2.6.10"
+
 vue-style-loader@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.2.tgz#dedf349806f25ceb4e64f3ad7c0a44fba735fcf8"
@@ -13642,6 +13721,14 @@ vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
+
+vue@^2.6.10:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.3.tgz#33015b7df481a515d625a2ea20fe01d981085cb7"
+  integrity sha512-7MTirXG7LYJi3r2jeYy7EiXIhEE85uP3kBwSxqwDsvIfy/l7+qR4U6ajw8ji1KoP+wYYg7ZY28TBTf3P3Fa4Nw==
+  dependencies:
+    "@vue/compiler-sfc" "2.7.3"
+    csstype "^3.1.0"
 
 vue@^2.6.14:
   version "2.6.14"


### PR DESCRIPTION
You vue-slick-carousel like we did for premium partners to create the new premium empoyers slider.  Below is examples when there is more than 4 and 4 or less.  


<img width="1111" alt="Screen Shot 2022-07-12 at 10 55 55 AM" src="https://user-images.githubusercontent.com/3845869/178537396-f0f2473f-a551-4f0b-add7-6d4ff43eb86a.png">
<img width="1110" alt="Screen Shot 2022-07-12 at 10 56 05 AM" src="https://user-images.githubusercontent.com/3845869/178537445-82277db7-c443-44d6-ba09-c14e84ae30ef.png">
<img width="391" alt="Screen Shot 2022-07-12 at 10 56 23 AM" src="https://user-images.githubusercontent.com/3845869/178537457-7ad01051-a563-4797-83e8-0efaffdfc26c.png">

