### PR TITLE
Use CSS styling over RegEx in order to correct sizing of Podcast page video

### DIFF
--- a/packages/global/components/layouts/website-section/podcast-feed.marko
+++ b/packages/global/components/layouts/website-section/podcast-feed.marko
@@ -87,7 +87,6 @@ $ const perPage = 10;
         }
       >
         <if(nodes[0].embedCode)>
-          $ nodes[0].embedCode = nodes[0].embedCode.replace(/(width=)"\d{3}"/g, '$1"100%"').replace(/height="\d{3}"/g, 'style="aspect-ratio: 16/9;"');
           <h2 class="page-wrapper__website-section-name watch-latest-rail">Watch our latest episode</h2>
           <marko-web-content-embed-code block-name=blockName obj=nodes[0] modifiers=["podcast-right-rail"] />
         </if>

--- a/packages/global/components/layouts/website-section/podcast-feed.marko
+++ b/packages/global/components/layouts/website-section/podcast-feed.marko
@@ -87,7 +87,7 @@ $ const perPage = 10;
         }
       >
         <if(nodes[0].embedCode)>
-          $ nodes[0].embedCode = nodes[0].embedCode.replace(/(width=|height=)"\d{3}"/g, '$1"100%"');
+          $ nodes[0].embedCode = nodes[0].embedCode.replace(/(width=)"\d{3}"/g, '$1"100%"').replace(/height="\d{3}"/g, 'style="aspect-ratio: 16/9;"');
           <h2 class="page-wrapper__website-section-name watch-latest-rail">Watch our latest episode</h2>
           <marko-web-content-embed-code block-name=blockName obj=nodes[0] modifiers=["podcast-right-rail"] />
         </if>

--- a/packages/global/components/layouts/website-section/podcast-feed.marko
+++ b/packages/global/components/layouts/website-section/podcast-feed.marko
@@ -87,7 +87,7 @@ $ const perPage = 10;
         }
       >
         <if(nodes[0].embedCode)>
-          $ nodes[0].embedCode = nodes[0].embedCode.replace(/\d{3}/g, '100%');
+          $ nodes[0].embedCode = nodes[0].embedCode.replace(/(width=|height=)"\d{3}"/g, '$1"100%"');
           <h2 class="page-wrapper__website-section-name watch-latest-rail">Watch our latest episode</h2>
           <marko-web-content-embed-code block-name=blockName obj=nodes[0] modifiers=["podcast-right-rail"] />
         </if>

--- a/packages/global/scss/components/_podcasts-page.scss
+++ b/packages/global/scss/components/_podcasts-page.scss
@@ -68,6 +68,11 @@
       padding: .75rem 0;
       text-align: center;
       border-bottom: 1px solid #e3e4e5;
+      iframe {
+        max-width: 100%;
+        aspect-ratio: 16/9;
+        height: initial;
+      }
     }
   }
 }


### PR DESCRIPTION
![Aspect](https://user-images.githubusercontent.com/46794001/184197375-69d850e4-3977-4079-be05-86180d8a4ca3.png)
