### PR TITLE
Add !showOverlay check to ads calls

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -27,12 +27,14 @@ $ const isOnTheMoveSection = new Set([83113]).has(primarySection.id);
   ...rest
 >
   <@section|{ aliases }| modifiers=["first-sm"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(!showOverlay)>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="content_page"
+        aliases=aliases
+        modifiers=["inter-block"]
+      />
+    </if>
   </@section>
 
   <@section|{ blockName, content, aliases }| modifiers=["content-header"]>
@@ -248,12 +250,14 @@ $ const isOnTheMoveSection = new Set([83113]).has(primarySection.id);
 
   <if(showBottomAdBlock)>
     <@section|{ aliases }|>
-      <theme-gam-define-display-ad
-        name="rotation"
-        position="content_page"
-        aliases=aliases
-        modifiers=["inter-block"]
-      />
+      <if(!showOverlay)>
+        <theme-gam-define-display-ad
+          name="rotation"
+          position="content_page"
+          aliases=aliases
+          modifiers=["inter-block"]
+        />
+      </if>
     </@section>
   </if>
 
@@ -274,13 +278,14 @@ $ const isOnTheMoveSection = new Set([83113]).has(primarySection.id);
       />
     </@section>
   </for>
-
   <@section|{ aliases }|>
-    <theme-gam-define-display-ad
-      name="rotation"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(!showOverlay)>
+      <theme-gam-define-display-ad
+        name="rotation"
+        position="content_page"
+        aliases=aliases
+        modifiers=["inter-block"]
+      />
+    </if>
   </@section>
 </global-content-wrapper-layout>


### PR DESCRIPTION
Only fire ads when the overlay is not displayed.
<img width="1350" alt="Screen Shot 2023-06-15 at 11 39 19 AM" src="https://github.com/parameter1/cox-matthews-associates-websites/assets/3845869/93d9f10d-d9be-4916-898e-d4dbc7dad67e">

