### PR TITLE
Add env/config based identity x user navigation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ x-env-defaults: &env
   SENDGRID_DEV_TO: developer@endeavorb2b.com
   YARN_CACHE_FOLDER: /.yarn-cache
   ENABLE_CONTENT_METER: ${ENABLE_CONTENT_METER-false}
+  IDX_NAV_ENABLE: ${IDX_NAV_ENABLE-false}
 
 x-env-virgon: &env-virgon
   GRAPHQL_URI: ${GRAPHQL_URI-https://virgon.graphql.base.parameter1.com}

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -104,13 +104,10 @@ $ const omedaConfig = site.get('omeda');
     <marko-web-gam-targeting key-values={ uri: req.path } />
   </@head>
   <@above-container>
-    <if("navbar2" === site.get("navigation.type"))>
-      <global-site-header-2 has-user=false reg-enabled=false />
-    </if>
-    <else>
-      <global-site-header has-user=false reg-enabled=false />
-    </else>
-    <global-site-menu has-user=false reg-enabled=false />
+    <marko-web-identity-x-context|{ hasUser, user, isEnabled }|>
+      <global-site-header-2 has-user=hasUser reg-enabled=isEnabled />
+      <global-site-menu has-user=hasUser reg-enabled=isEnabled />
+    </marko-web-identity-x-context>
     <if(contentMeterState && !contentMeterState.isLoggedIn)>
       <global-content-meter-block
         views=contentMeterState.views

--- a/packages/global/components/site-menu/index.marko
+++ b/packages/global/components/site-menu/index.marko
@@ -21,6 +21,15 @@ $ const hasUser = defaultValue(input.hasUser, false);
       <div class="col-6 col-md-4 col-lg-3">
         <!-- search box -->
         <search block-name=blockName />
+        <theme-site-menu-section
+          tag="nav"
+          block-name=blockName
+          label="Account"
+          items=site.getAsArray("navigation.user")
+          modifiers=["secondary", "user"]
+          reg-enabled=regEnabled
+          has-user=hasUser
+        />
         <!-- social -->
         <social-icons block-name=blockName title="Follow Us" />
         <!-- about section -->
@@ -76,6 +85,15 @@ $ const hasUser = defaultValue(input.hasUser, false);
   <marko-web-element block-name=blockName name="contents-mobile">
     <!-- search box -->
     <search block-name=blockName />
+    <theme-site-menu-section
+      tag="nav"
+      block-name=blockName
+      label="Account"
+      items=site.getAsArray("navigation.user")
+      modifiers=["secondary", "user"]
+      reg-enabled=regEnabled
+      has-user=hasUser
+    />
     <!-- social -->
     <social-icons block-name=blockName />
     <!-- primary section -->

--- a/packages/global/config/identity-x-nav.js
+++ b/packages/global/config/identity-x-nav.js
@@ -1,0 +1,42 @@
+const { isArray } = Array;
+
+module.exports = ({ site }) => {
+  const idxConfig = site.get('identityX');
+
+  const enabled = site.get('idxNavItems.enable');
+  if (!enabled) return;
+  const defaultTargets = [
+    'navigation.user',
+  ];
+  const targets = site.getAsArray('idxNavItems.navigationTargets').length ? site.getAsArray('idxNavItems.navigationTargets') : defaultTargets;
+  const navConfig = [
+    {
+      href: idxConfig.getEndpointFor('login'),
+      label: 'Sign In',
+      when: 'logged-out',
+      modifiers: ['user'],
+    },
+    {
+      href: idxConfig.getEndpointFor('profile'),
+      label: 'Manage Account',
+      when: 'logged-in',
+      modifiers: ['user'],
+    },
+    {
+      href: idxConfig.getEndpointFor('logout'),
+      label: 'Sign Out',
+      when: 'logged-in',
+      modifiers: ['user'],
+    },
+    // {
+    //   href: idxConfig.getEndpointFor('register'),
+    //   label: 'Sign Up',
+    //   when: 'logged-out',
+    //   modifiers: ['user'],
+    // },
+  ];
+  targets.forEach((target) => {
+    const nav = site.get(target);
+    if (isArray(nav)) nav.unshift(...navConfig);
+  });
+};

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -468,6 +468,10 @@ label {
   }
 }
 
+.site-menu__section--user {
+  @include marko-web-node-list-border(border-bottom);
+}
+
 .page {
   &--authenticate,
   &--profile,

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -13,6 +13,7 @@ const paginated = require('./middleware/paginated');
 const redirectHandler = require('./redirect-handler');
 const oembedHandler = require('./oembed-handler');
 const idxRouteTemplates = require('./templates/user');
+const idxNavItems = require('./config/identity-x-nav');
 
 const routes = (siteRoutes) => (app, siteConfig) => {
   // Shared/global routes (all sites)
@@ -49,6 +50,7 @@ module.exports = (options = {}) => {
       const omedaIdentityXConfig = getAsObject(options, 'siteConfig.omedaIdentityX');
       set(app.locals, 'omedaConfig', getAsObject(options, 'siteConfig.omeda'));
       omedaIdentityX(app, { ...omedaIdentityXConfig, idxRouteTemplates });
+      idxNavItems({ site: app.locals.site });
 
       // Setup GAM.
       const gamConfig = get(options, 'siteConfig.gam');

--- a/sites/ccnewsnow.com/config/navigation.js
+++ b/sites/ccnewsnow.com/config/navigation.js
@@ -46,6 +46,7 @@ const desktopMenu = {
 
 module.exports = {
   type: 'navbar2',
+  user: [],
   promos: [
     {
       title: subscribe.label,

--- a/sites/ccnewsnow.com/config/site.js
+++ b/sites/ccnewsnow.com/config/site.js
@@ -15,6 +15,9 @@ module.exports = {
   nativeX,
   omeda,
   identityX,
+  idxNavItems: {
+    enable: process.env.IDX_NAV_ENABLE === 'true',
+  },
   omedaIdentityX,
   identityXOptInHooks,
   gam,

--- a/sites/diverseeducation.com/config/navigation.js
+++ b/sites/diverseeducation.com/config/navigation.js
@@ -80,6 +80,7 @@ module.exports = {
   ],
   desktopMenu,
   mobileMenu,
+  user: [],
   topics,
   primary: {
     items: [

--- a/sites/diverseeducation.com/config/site.js
+++ b/sites/diverseeducation.com/config/site.js
@@ -19,6 +19,9 @@ module.exports = {
   nativeX,
   omeda,
   identityX,
+  idxNavItems: {
+    enable: process.env.IDX_NAV_ENABLE === 'true',
+  },
   omedaIdentityX,
   identityXOptInHooks,
   gam,

--- a/sites/diversemilitary.net/config/navigation.js
+++ b/sites/diversemilitary.net/config/navigation.js
@@ -48,6 +48,7 @@ const desktopMenu = {
 
 module.exports = {
   type: 'navbar2',
+  user: [],
   promos: [
     {
       title: subscribe.label,

--- a/sites/diversemilitary.net/config/site.js
+++ b/sites/diversemilitary.net/config/site.js
@@ -4,6 +4,7 @@ const gam = require('./gam');
 const omeda = require('./omeda');
 const identityX = require('./identity-x');
 const omedaIdentityX = require('./omeda-identity-x');
+const identityXOptInHooks = require('./identity-x-opt-in-hooks');
 const newsletter = require('./newsletter');
 const search = require('./search');
 const contentMeter = require('./content-meter');
@@ -14,7 +15,11 @@ module.exports = {
   nativeX,
   omeda,
   identityX,
+  idxNavItems: {
+    enable: process.env.IDX_NAV_ENABLE === 'true',
+  },
   omedaIdentityX,
+  identityXOptInHooks,
   gam,
   newsletter,
   search,

--- a/sites/divhealth.net/config/navigation.js
+++ b/sites/divhealth.net/config/navigation.js
@@ -32,6 +32,7 @@ const utilities = [
 
 const mobileMenu = {
   type: 'navbar2',
+  user: [],
   promos: [
     {
       title: 'Subscribe to Diverse Education',

--- a/sites/divhealth.net/config/site.js
+++ b/sites/divhealth.net/config/site.js
@@ -15,6 +15,9 @@ module.exports = {
   nativeX,
   omeda,
   identityX,
+  idxNavItems: {
+    enable: process.env.IDX_NAV_ENABLE === 'true',
+  },
   omedaIdentityX,
   identityXOptInHooks,
   gam,


### PR DESCRIPTION
Add the ability to set the idxNavItems.enable prop based on IDX_NAV_ENABLE env prop.  when set to true the Account section is added to the expanded nav and mobile menu.

### By default this is disabled

![Screen Shot 2023-07-14 at 3 23 09 PM](https://github.com/parameter1/cox-matthews-associates-websites/assets/3845869/57bf171c-5c7c-443b-82c2-59839853416c)
![Screen Shot 2023-07-14 at 3 23 15 PM](https://github.com/parameter1/cox-matthews-associates-websites/assets/3845869/c533fec4-3ec3-4e3a-9d2d-cb239ac0c265)
