### PR TITLE
Correct `On The Move` embedded image styling

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -168,6 +168,7 @@ $ const isOnTheMoveSection = new Set([83113]).has(primarySection.id);
               block-name=blockName
               preventHTMLInjection=!shouldInjectAds
               lazyload-first-image=lazyloadFirstImage
+              modifiers=bodyModifiers
             />
             <if(content.transcript)>
               <div id=`transcript-${id}` class="page-contents__content-transcript">

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -293,7 +293,9 @@
 
 // skin components
 /*! critical:start|website-section.on-the-move */
+/*! purgecss start ignore */
 @import "./components/on-the-move-page";
+/*! purgecss end ignore */
 /*! critical:start|end */
 /*! critical:start|website-section.podcast */
 /*! critical:start|content */


### PR DESCRIPTION
PRODUCTION:
![Screenshot from 2023-07-26 08-55-07](https://github.com/parameter1/cox-matthews-associates-websites/assets/46794001/2423ee03-269b-49ae-a230-e3e71c9b8cad)

DEVELOPMENT:
![Screenshot from 2023-07-26 09-21-25](https://github.com/parameter1/cox-matthews-associates-websites/assets/46794001/7a2ee135-79a5-4665-9f09-d9c4c08e09a0)


Due to changes in how CSS is included embedded image styling (such as that found here: https://github.com/parameter1/cox-matthews-associates-websites/blob/master/packages/global/scss/components/_on-the-move-page.scss#L10) is purged automatically due to these elements not being on the page at render time (or something to that effect), essentially whenever the CSS is built it doesn't know that these elements/attributes exist on the page and purges them.

Reference: https://github.com/parameter1/base-cms/commit/9bf5b44d4dd9843b0b3474709ceaaaac0a828349 