### PR TITLE
Remove text-decoration on  a:hover

### DIFF
--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -279,7 +279,7 @@
         // stylelint-disable-next-line selector-max-compound-selectors
         &__section {
           // stylelint-disable-next-line selector-max-compound-selectors
-          > .social-icon-link {
+          .social-icon-link {
             // stylelint-disable-next-line
             &:last-of-type {
               margin-right: 0;
@@ -291,6 +291,11 @@
   }
 }
 
+a {
+  &:hover {
+    text-decoration: none;
+  }
+}
 
 // skin components
 /*! critical:start|website-section.on-the-move */

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -279,7 +279,7 @@
         // stylelint-disable-next-line selector-max-compound-selectors
         &__section {
           // stylelint-disable-next-line selector-max-compound-selectors
-          .social-icon-link {
+          > .social-icon-link {
             // stylelint-disable-next-line
             &:last-of-type {
               margin-right: 0;


### PR DESCRIPTION
<img width="651" alt="Screen Shot 2023-09-20 at 9 55 11 AM" src="https://github.com/parameter1/cox-matthews-associates-websites/assets/64623209/2455d248-ce4b-4c48-b4b9-a43cfc2d99bb">

Privacy policy still is underlined when hovered on
<img width="427" alt="Screen Shot 2023-09-20 at 9 56 57 AM" src="https://github.com/parameter1/cox-matthews-associates-websites/assets/64623209/dab04f52-8ac6-4982-bf22-739bb691dc79">
