### PR TITLE
Adjust margin-right scss to keep social icons on 1 line

### DIFF
--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -473,10 +473,14 @@ label {
       &__header {
         line-height: 1.5;
       }
+      &__section {
+        .social-icon-link {
+          margin-right: 14px;
+        }
+      }
     }
   }
 }
-
 .site-menu__section--user {
   @include marko-web-node-list-border(border-bottom);
 }


### PR DESCRIPTION
<img width="570" alt="Screen Shot 2023-11-22 at 11 55 16 AM" src="https://github.com/parameter1/cox-matthews-associates-websites/assets/64623209/4e6de50e-53cf-4ca4-9375-a76734754e6f">
<img width="1314" alt="Screen Shot 2023-11-22 at 11 55 00 AM" src="https://github.com/parameter1/cox-matthews-associates-websites/assets/64623209/0aed3993-3dfa-4763-970a-b8490b66d7b2">
