### PR TITLE
Adding ?v=ID will swap leaderboard for greeting video

### DIFF
--- a/packages/global/components/layouts/content/company.marko
+++ b/packages/global/components/layouts/content/company.marko
@@ -4,6 +4,8 @@ import imageHeight from "@parameter1/base-cms-marko-web/components/node/utils/im
 
 $ const { id, type, pageNode, ...rest } = input;
 $ const sections = getAsArray(input, "sections");
+$ const { req } = out.global;
+$ const { v } = req.query;
 
 <global-content-wrapper-layout
   id=id
@@ -12,12 +14,23 @@ $ const sections = getAsArray(input, "sections");
   ...rest
 >
   <@section|{ aliases }| modifiers=["first-sm"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ aliases, blockName, content }| modifiers=["content-header"]>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -6,6 +6,8 @@ import { cmShowOverlay, cmRestrictContentByReg, cmTruncateBody } from "../../../
 import shuffle from "../../../utils/shuffle-array";
 
 $ const { site, contentMeterState } = out.global;
+$ const { req } = out.global;
+$ const { v } = req.query;
 $ const idxConfig = site.getAsObject('identityX');
 $ const recommendedQuestionId = get(idxConfig, 'options.recommendedQuestionId');
 
@@ -32,12 +34,23 @@ $ const isOnTheMoveSection = new Set([83113]).has(primarySection.id);
 >
   <@section|{ aliases }| modifiers=["first-sm"]>
     <if(!showOverlay)>
-      <theme-gam-define-display-ad
-        name="leaderboard"
-        position="content_page"
-        aliases=aliases
-        modifiers=["inter-block"]
-      />
+      <if(v)>
+        <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+          <div class="ad-container__wrapper">
+            <div style="border: 0pt none;">
+              <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+            </div>
+          </div>
+        </div>
+      </if>
+      <else>
+        <theme-gam-define-display-ad
+          name="leaderboard"
+          position="home_page"
+          aliases=aliases
+          modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+        />
+      </else>
     </if>
   </@section>
 

--- a/packages/global/components/layouts/content/product.marko
+++ b/packages/global/components/layouts/content/product.marko
@@ -2,6 +2,8 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const { id, type, pageNode, ...rest } = input;
 $ const sections = getAsArray(input, "sections");
+$ const { req } = out.global;
+$ const { v } = req.query;
 
 <global-content-wrapper-layout
   id=id
@@ -10,12 +12,23 @@ $ const sections = getAsArray(input, "sections");
   ...rest
 >
   <@section|{ aliases }| modifiers=["first-sm"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ aliases, blockName, content }| modifiers=["content-header"]>

--- a/packages/global/components/layouts/content/whitepaper.marko
+++ b/packages/global/components/layouts/content/whitepaper.marko
@@ -2,6 +2,8 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const { site } = out.global;
 $ const { id, type, pageNode, ...rest } = input;
+$ const { req } = out.global;
+$ const { v } = req.query;
 
 <global-content-wrapper-layout
   id=id
@@ -10,12 +12,23 @@ $ const { id, type, pageNode, ...rest } = input;
   ...rest
 >
   <@section|{ aliases }| modifiers=["first-sm"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ blockName, content, aliases }| modifiers=["content-header"]>

--- a/packages/global/components/layouts/website-section/cards.marko
+++ b/packages/global/components/layouts/website-section/cards.marko
@@ -3,8 +3,9 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
 
-$ const { pagination: p } = out.global;
+$ const { pagination: p, req } = out.global;
 $ const perPage = 10;
+$ const { v } = req.query;
 
 <global-website-section-default-layout
   id=id
@@ -24,12 +25,23 @@ $ const perPage = 10;
   </@head>
 
   <@section|{ aliases }| modifiers=["first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ blockName, section, aliases }|>

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -3,8 +3,9 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
 
-$ const { pagination: p } = out.global;
+$ const { pagination: p, req } = out.global;
 $ const perPage = 18;
+$ const { v } = req.query;
 
 <global-website-section-default-layout
   id=id
@@ -24,12 +25,23 @@ $ const perPage = 18;
   </@head>
 
   <@section|{ aliases }| modifiers=["first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ blockName, section, aliases }|>

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -3,6 +3,8 @@ import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql
 
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
+$ const { req } = out.global;
+$ const { v } = req.query;
 
 <global-website-section-default-layout
   id=id
@@ -12,12 +14,23 @@ $ const sections = getAsArray(input, "sections");
   head=input.head
 >
   <@section|{ aliases }| modifiers=["first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="home_page"
-      aliases=aliases
-      modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ aliases }|>

--- a/packages/global/components/layouts/website-section/podcast-feed.marko
+++ b/packages/global/components/layouts/website-section/podcast-feed.marko
@@ -4,7 +4,8 @@ import queryFragment from '../../../graphql/fragments/content-page'
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
 
-$ const { pagination: p, site } = out.global;
+$ const { pagination: p, site, req } = out.global;
+$ const { v } = req.query;
 $ const wufooUserName = site.get("wufoo.userName");
 $ const wufooPodcastFormHash = site.get("wufoo.podcastFormHash");
 
@@ -28,12 +29,23 @@ $ const perPage = 10;
   </@head>
 
   <@section|{ aliases }| modifiers=["first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ blockName, section, aliases }|>

--- a/packages/global/components/layouts/website-section/products.marko
+++ b/packages/global/components/layouts/website-section/products.marko
@@ -4,8 +4,9 @@ import queryFragment from "@parameter1/base-cms-marko-web-theme-monorail/graphql
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
 
-$ const { pagination: p } = out.global;
+$ const { pagination: p, req } = out.global;
 $ const perPage = 10;
+$ const { v } = req.query;
 
 <global-website-section-default-layout
   id=id
@@ -25,12 +26,23 @@ $ const perPage = 10;
   </@head>
 
   <@section|{ aliases }| modifiers=["first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ blockName, section, aliases }|>

--- a/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-archive-feed.marko
@@ -3,6 +3,8 @@ $ const now = Date.now();
 
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
+$ const { req } = out.global;
+$ const { v } = req.query;
 
 $ const queryParams = {
   includeContentTypes: ["Webinar"],
@@ -34,12 +36,23 @@ $ const perPage = 18;
   </@head>
 
   <@section|{ aliases }| modifiers=["first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="section_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ blockName, section, aliases }|>

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -499,4 +499,15 @@ label {
   }
 
 }
+.ad-container {
+  $self: &;
+  &--video {
+    > *:first-child {
+      &::before {
+        content: "Holiday Greetings!";
+      }
+    }
+  }
+}
+
 /*! critical:end */

--- a/packages/global/templates/content/contact.marko
+++ b/packages/global/templates/content/contact.marko
@@ -5,6 +5,7 @@ $ const { id, type, pageNode } = data;
 
 $ const { pagination: p, req } = out.global;
 $ const perPage = 10;
+$ const { v } = req.query;
 
 <global-content-wrapper-layout
   id=id
@@ -12,12 +13,23 @@ $ const perPage = 10;
   page-node=pageNode
 >
   <@section|{ aliases }| modifiers=["first-sm"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ content }|>

--- a/packages/global/templates/dynamic-page/index.marko
+++ b/packages/global/templates/dynamic-page/index.marko
@@ -1,4 +1,6 @@
 $ const { id, type, pageNode } = input;
+$ const { req } = out.global;
+$ const { v } = req.query;
 
 <global-content-wrapper-layout
   id=id
@@ -7,12 +9,23 @@ $ const { id, type, pageNode } = input;
 >
 
   <@section|{ aliases }| modifiers=["first"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
+    <if(v)>
+      <div class="ad-container ad-container--with-label ad-container--video ad-container--max-width-970 ad-container--center ad-container--margin-auto-x ad-container--inline ad-container--template-leaderboard">
+        <div class="ad-container__wrapper">
+          <div style="border: 0pt none;">
+            <iframe width="560" height="315" src=`https://www.youtube.com/embed/${v}` title="" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+          </div>
+        </div>
+      </div>
+    </if>
+    <else>
+      <theme-gam-define-display-ad
+        name="leaderboard"
+        position="home_page"
+        aliases=aliases
+        modifiers=["max-width-970", "center", "margin-auto-x", "inline"]
+      />
+    </else>
   </@section>
 
   <@section|{ blockName, content }|>


### PR DESCRIPTION
Adding `v=${videoID} will swap out the leaderboard for the corresponding video on there pages.  

<img width="1168" alt="Screenshot 2023-12-04 at 10 17 44 AM" src="https://github.com/parameter1/cox-matthews-associates-websites/assets/3845869/79370bfd-ec10-495a-99e1-1cec83d7f1e4">
<img width="1112" alt="Screenshot 2023-12-04 at 10 17 32 AM" src="https://github.com/parameter1/cox-matthews-associates-websites/assets/3845869/55cb3f1f-2cf1-433a-8170-559924a23de8">
<img width="1123" alt="Screenshot 2023-12-04 at 10 17 21 AM" src="https://github.com/parameter1/cox-matthews-associates-websites/assets/3845869/96b04a09-1c9c-4c12-804d-d992a09b261f">
