### PR TITLE
Exclude Video type content from paginated counts, Podcast page

### DIFF
--- a/packages/global/components/layouts/website-section/podcast-feed.marko
+++ b/packages/global/components/layouts/website-section/podcast-feed.marko
@@ -18,6 +18,7 @@ $ const perPage = 10;
 >
   <@head>
     <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <@query-params exclude-content-types=["Video"] />
       <theme-pagination-controls
         per-page=perPage
         total-count=totalCount
@@ -118,6 +119,7 @@ $ const perPage = 10;
     </div>
 
     <theme-section-feed-block|{ totalCount }| alias=alias count-only=true>
+      <@query-params exclude-content-types=["Video"] />
       <theme-pagination-controls
         per-page=perPage
         total-count=totalCount


### PR DESCRIPTION
Because the actual display logic excludes these the additional pages "load nothing" so pages 14-17 no longer are included in the pagination as a result of this change

PRODUCTION:
![Screenshot from 2023-12-08 07-57-36](https://github.com/parameter1/cox-matthews-associates-websites/assets/46794001/1b30e683-86e9-4d3e-840a-e8cb2a7f8f6b)

DEVELOPMENT:
![Screenshot from 2023-12-08 07-58-13](https://github.com/parameter1/cox-matthews-associates-websites/assets/46794001/c16a1da9-1735-4cf3-8843-d32393c52f5a)
