### PR TITLE
Adjust suggested video embed prop, styles & playback

### DIFF
--- a/packages/global/components/blocks/suggested-video.marko
+++ b/packages/global/components/blocks/suggested-video.marko
@@ -5,7 +5,7 @@ $ const suggestedVideoPlaylist = site.get('suggestedVideoPlaylist') ? site.get('
 <div class="ad-container ad-container--with-label ad-container--video ad-container--center ad-container--margin-auto-x ad-container--template-suggested-video">
   <div class="ad-container__wrapper">
     <div style="border: 0pt none;">
-      <iframe width="640" height="480" src=`https://www.youtube.com/embed/${suggestedVideoID}?rel=0;si=&amp;loop=1&autoplay=1&mute=1&playlist=${suggestedVideoPlaylist}` title="Youtube Player" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
+      <iframe width="640" height="480" src=`https://www.youtube.com/embed/${suggestedVideoID}?playlist=${suggestedVideoPlaylist}&widget_referrer=suggested-content&rel=0&autoplay=1&mute=0}` title="Youtube Player" frameBorder="0"   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"  allowFullScreen></iframe>
     </div>
   </div>
 </div>

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -71,6 +71,9 @@ $ const perPage = 12;
           <@native-x index=[1] name="default" aliases=aliases sectionName="Sponsored" />
         </if>
         <@rail>
+          <if(site.get('suggestedVideoID'))>
+            <global-suggested-video-block />
+          </if>
           <!-- Remobe sticky top if you add user stuff back. -->
           <div class="mb-block sticky-top">
             <theme-gam-define-display-ad
@@ -89,9 +92,6 @@ $ const perPage = 12;
           </marko-web-identity-x-context> -->
         </@rail>
         <@rail>
-          <if(site.get('suggestedVideoID'))>
-            <global-suggested-video-block />
-          </if>
           <theme-client-side-most-popular-list-block class="sticky-top" />
         </@rail>
       </global-section-feed-wrapper>

--- a/packages/global/scss/components/_ads.scss
+++ b/packages/global/scss/components/_ads.scss
@@ -34,8 +34,8 @@
     }
     iframe {
       aspect-ratio: 16 / 9;
-      // max-width: 100%;
-      max-width: 300px;
+      max-width: 100%;
+      // max-width: 300px;
       height: auto;
     }
   }


### PR DESCRIPTION
update props and allow for it to span full width within the rail.  It will also auto play unmuted. :( 

@todo figure out how to hide related videos at the end. 

![Screenshot 2024-01-12 at 11 28 50 AM](https://github.com/parameter1/cox-matthews-associates-websites/assets/3845869/109f6adb-b898-4638-bcae-2475d4bdf586)
