### PR TITLE
Create global version of content meter to allow for custom text

### DIFF
--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -3,10 +3,12 @@ import ContactUs from '@parameter1/base-cms-marko-web-contact-us/browser';
 import MonoRail from '@parameter1/base-cms-marko-web-theme-monorail/browser';
 
 const GlobalPremiumEmployers = () => import(/* webpackChunkName: "global-premium-employers" */ './premium-employers.vue');
+const ContentMeterTrack = () => import(/* webpackChunkName: "content-meter-tracker" */ './track-content-meter.vue');
 
 export default (Browser) => {
   GCSE(Browser);
   ContactUs(Browser);
   MonoRail(Browser);
   Browser.register('GlobalPremiumEmployers', GlobalPremiumEmployers);
+  Browser.register('ContentMeterTrack', ContentMeterTrack);
 };

--- a/packages/global/browser/track-content-meter.vue
+++ b/packages/global/browser/track-content-meter.vue
@@ -1,0 +1,59 @@
+<template>
+  <div id="content-meter-gtm-event" />
+</template>
+
+<script>
+
+export default {
+  props: {
+    views: {
+      type: Number,
+      default: 0,
+    },
+    viewLimit: {
+      type: Number,
+      default: 3,
+    },
+    displayGate: {
+      type: Boolean,
+      default: false,
+    },
+    displayOverlay: {
+      type: Boolean,
+      required: false,
+    },
+  },
+  computed: {
+    remaining() {
+      const { viewLimit, views } = this;
+      return viewLimit - views;
+    },
+    overlayDisplayed() {
+      const { displayGate, displayOverlay } = this;
+      return displayGate && displayOverlay;
+    },
+  },
+  created() {
+    const { views, remaining, overlayDisplayed } = this;
+    this.observer = new IntersectionObserver((event) => {
+      if (event[0].isIntersecting) {
+        const { dataLayer } = window;
+        if (dataLayer) {
+          dataLayer.push({
+            event: 'identity-x-content-meter-view',
+            'identity-x': {
+              label: 'content-meter',
+              views,
+              remaining,
+              overlayDisplayed,
+            },
+          });
+        }
+      }
+    });
+  },
+  mounted() {
+    this.observer.observe(this.$el);
+  },
+};
+</script>

--- a/packages/global/components/blocks/content-meter.marko
+++ b/packages/global/components/blocks/content-meter.marko
@@ -1,0 +1,71 @@
+$ const { config, site, contentMeterState } = out.global;
+$ const {
+  displayGate,
+  displayOverlay,
+  viewLimit,
+  views,
+} = contentMeterState;
+$ const additionalEventData = {
+  promoCode: site.get("contentMeter.promoCode", undefined),
+  views,
+  viewLimit,
+  displayGate,
+  displayOverlay,
+};
+
+$ function setTextVariables() {
+  // Set title based on views remaining
+  let dynamicTitle = "We hope you’ve enjoyed your articles."
+  if (views < viewLimit) dynamicTitle = `You have ${viewLimit - views} article views remaining.`;
+  if (viewLimit - views === 1) dynamicTitle = `You have 1 article view remaining.`;
+
+  return [
+    dynamicTitle,
+    "Create a free account",
+    `Create a free <span class="content-meter__call-to-action--site-name">${config.siteName()}</span> account to continue reading. Already have an account? Enter your email to access the article.`,
+    "Continue",
+  ];
+}
+$ const [title, collapsedTitle, callToAction, registerText] = setTextVariables();
+
+$ const classes = [
+  "content-meter",
+  "content-meter--open",
+  `${(displayGate && displayOverlay) ? "content-meter--display-overlay" : "" }`,
+].join(" ");
+
+<div class=classes>
+  <if(displayGate && displayOverlay)>
+    <div class="content-meter__overlay"/>
+  </if>
+  <div class="content-meter__bar">
+    <global-content-meter-track />
+    <div class="content-meter__title">
+      <theme-menu-toggle-button
+        class="content-meter__toggler"
+        targets=[
+          ".content-meter"
+        ]
+        beforeExpanded=`${title}`
+        beforeCollapsed=`${collapsedTitle}`
+        toggle-class="content-meter--open"
+        icon-modifiers=["xl"]
+        initially-expanded=true
+        icon-name="chevron-up"
+        expanded-icon-name="chevron-down"
+      />
+    </div>
+    <p class="content-meter__call-to-action">
+      $!{callToAction}
+    </p>
+    <div class="content-meter__body">
+      <div class="content-meter__login-form">
+        <marko-web-identity-x-form-login
+          login-email-placeholder="your@email.com"
+          source="content_meter_login"
+          additional-event-data=additionalEventData
+        />
+      </div>
+    </div>
+  </div>
+</div>

--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -35,5 +35,8 @@
     "@ad-name": "string",
     "@ad-position": "string",
     "@count-only": "boolean"
+  },
+  "<global-content-meter-block>": {
+    "template": "./content-meter.marko"
   }
 }

--- a/packages/global/components/content-meter-track.marko
+++ b/packages/global/components/content-meter-track.marko
@@ -1,0 +1,14 @@
+$ const { contentMeterState } = out.global;
+$ const {
+  displayGate,
+  displayOverlay,
+  viewLimit,
+  views,
+} = contentMeterState;
+
+<marko-web-browser-component name="ContentMeterTrack" props={
+  views: views,
+  viewLimit: viewLimit,
+  displayOverlay: displayOverlay,
+  displayGate: displayGate,
+} />

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -82,7 +82,7 @@ $ const omedaConfig = site.get('omeda');
       <global-site-menu has-user=hasUser reg-enabled=isEnabled />
     </marko-web-identity-x-context>
     <if(contentMeterState && !contentMeterState.isLoggedIn)>
-      <theme-content-meter-block
+      <global-content-meter-block
         views=contentMeterState.views
         view-limit=contentMeterState.viewLimit
         display-overlay=contentMeterState.displayOverlay

--- a/packages/global/components/marko.json
+++ b/packages/global/components/marko.json
@@ -39,5 +39,8 @@
   },
   "<global-social-icon-link>": {
     "template": "./social-icon-link.marko"
+  },
+  "<global-content-meter-track>": {
+    "template": "./content-meter-track.marko"
   }
 }


### PR DESCRIPTION
<img width="1792" alt="Screenshot 2024-11-07 at 10 36 29 AM" src="https://github.com/user-attachments/assets/ee884035-09ad-4347-8d56-6fa460bafaf1">
<img width="1686" alt="Screenshot 2024-11-07 at 10 30 48 AM" src="https://github.com/user-attachments/assets/d55d611b-84a1-4b3c-8c4c-bd23a497502c">
<img width="678" alt="Screenshot 2024-11-07 at 10 30 40 AM" src="https://github.com/user-attachments/assets/5a2d02fa-d6b8-40b6-ba6a-49d7c3acdb05">
