### PR TITLE
Disable outbound link tracking

### DIFF
--- a/packages/global/templates/content/advertising-post.marko
+++ b/packages/global/templates/content/advertising-post.marko
@@ -45,7 +45,7 @@ $ const { primarySection } = content;
       </@section>
     </marko-web-page-wrapper>
 
-    <marko-web-native-x-story-track-outbound-links container="#native-x-story-body" />
+    <!-- <marko-web-native-x-story-track-outbound-links container="#native-x-story-body" /> -->
     <marko-web-native-x-story-track-end-of-content />
   </@page>
 </theme-default-page>

--- a/packages/global/templates/content/native-x-story.marko
+++ b/packages/global/templates/content/native-x-story.marko
@@ -45,7 +45,7 @@ $ const { primarySection } = content;
       </@section>
     </marko-web-page-wrapper>
 
-    <marko-web-native-x-story-track-outbound-links container="#native-x-story-body" />
+    <!-- <marko-web-native-x-story-track-outbound-links container="#native-x-story-body" /> -->
     <marko-web-native-x-story-track-end-of-content />
   </@page>
 </theme-default-page>


### PR DESCRIPTION
Causes "open in new tab" to fail