### PR TITLE
Prevent right rail ad from firing behind overlay

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -308,13 +308,15 @@ $ const withRecommended = defaultValue(input.withRecommended, true);
         <!-- <if(site.get('suggestedVideoID'))>
           <global-suggested-video-block />
         </if> -->
-        <theme-gam-define-display-ad
-          name="right-rail"
-          position="content_page"
-          aliases=aliases
-          modifiers=["max-width-300", "center", "margin-auto-x", "rail"]
-          class="mb-block"
-        />
+        <if(!showOverlay)>
+          <theme-gam-define-display-ad
+            name="right-rail"
+            position="content_page"
+            aliases=aliases
+            modifiers=["max-width-300", "center", "margin-auto-x", "rail"]
+            class="mb-block"
+          />
+        </if>
         <if(withRecommended)>
           <div class="sticky-top">
             <global-recommended-content-block query-params={ excludeContentIds: [content.id], sectionId: primarySection.id } aliases=aliases />


### PR DESCRIPTION
https://trello.com/c/Gz3tXeOf/501-ad-slot-for-video-on-article-pages

Now:
<img width="1730" alt="Screenshot 2025-06-16 at 9 54 30 AM" src="https://github.com/user-attachments/assets/68e6e42d-61dc-4298-8b54-21c755b1d2c6" />

Before:
<img width="1050" alt="Screenshot 2025-06-16 at 9 54 47 AM" src="https://github.com/user-attachments/assets/8c3cb80f-4a80-4d88-b8cb-98cab52380ac" />
