### PR TITLE
Specific inbody ad targeting for desktop ad hiding

### DIFF
--- a/packages/global/scss/components/_ads.scss
+++ b/packages/global/scss/components/_ads.scss
@@ -15,7 +15,6 @@
 }
 .ad-container {
   $self: &;
-
   &--inline-content,
   &--inline-section-feed  {
     background-color: #fff;
@@ -37,6 +36,17 @@
       max-width: 100%;
       // max-width: 300px;
       height: auto;
+    }
+  }
+}
+.page-contents__content-body {
+  .ad-container {
+    &--template-inline-content-desktop {
+      margin-bottom: initial;
+      min-height: initial !important;
+      &:has(.ad-container__wrapper > div:not(:empty)) {
+        margin-bottom: map-get($spacers, block);
+      }
     }
   }
 }


### PR DESCRIPTION
More specifically the hiding of desktop ads when not filled. 

<img width="497" height="851" alt="Screenshot 2025-09-30 at 11 11 34 AM" src="https://github.com/user-attachments/assets/552c423a-530b-4438-beb4-8ea99cf38741" />
<img width="730" height="946" alt="Screenshot 2025-09-30 at 11 11 50 AM" src="https://github.com/user-attachments/assets/9e67b212-4269-490b-8317-7358a40663f8" />
